### PR TITLE
docs: migration guide for the new open-source rebuild

### DIFF
--- a/.wolf/STATUS.md
+++ b/.wolf/STATUS.md
@@ -30,6 +30,8 @@ belongs to — never deferred to a cleanup pass.
   - `04-pitfalls.md` — 24 verified defects (P-01..P-24) with evidence
   - `05-phase-plan.md` — phases 0-10, **this is living state, tick tasks there**
   - `06-quality-bar.md` — definition of done
+  - `07-agent-tooling.md` — agent toolchain: hooks/lint enforcement, OpenWolf, kanban-md,
+    Ponytail, design-system skill, Playwright MCP, TDD policy
 - Cross-references validated: 24/24 pitfalls, 15/15 features, 7/7 ADRs, no dead links
 - Stack decision made and closed: **Vite + React 19 + TanStack Router (SPA/PWA)**
 

--- a/.wolf/STATUS.md
+++ b/.wolf/STATUS.md
@@ -2,63 +2,120 @@
 
 > Single source of truth for resuming work. Read this FIRST when starting a session.
 > Update this file at the end of every work phase so the next `/clear` resumes in 1 read.
-> Last updated: 2026-07-18
+> Last updated: 2026-07-26
+
+---
+
+## 🧭 Context
+
+This repo (`tempest`) is being **replaced** by a new, clean, open-source-from-day-zero app:
+new brand, fully redesigned UI, **same features**. Hence "migration", not "rewrite".
+
+The migration runs incrementally, one feature at a time, executed by AI agents. Every
+improvement (i18n, tests, naming, structure) is made **during** the migration of the part it
+belongs to — never deferred to a cleanup pass.
+
+**The migration guide lives in `docs/migration/`. It is the spec.** Start at
+`docs/migration/README.md`.
 
 ---
 
 ## ✅ Done
 
-<!-- Move items here from "🚀 Next phase" when finished. Group by area. -->
-
-- (nothing yet — fill in as work completes)
+- **Migration guide written** (`docs/migration/`, 7 documents, ~23k tokens total)
+  - `README.md` — index, the three rules, per-session protocol
+  - `01-target-architecture.md` — 7 ADRs, all closed
+  - `02-feature-inventory.md` — 15 features mapped (F-01..F-15)
+  - `03-domain-model.md` — canonical types, invariants, old→new import map
+  - `04-pitfalls.md` — 24 verified defects (P-01..P-24) with evidence
+  - `05-phase-plan.md` — phases 0-10, **this is living state, tick tasks there**
+  - `06-quality-bar.md` — definition of done
+- Cross-references validated: 24/24 pitfalls, 15/15 features, 7/7 ADRs, no dead links
+- Stack decision made and closed: **Vite + React 19 + TanStack Router (SPA/PWA)**
 
 ---
 
 ## 🚀 Next phase
 
-**Goal:** _<what we're building next, in 1 sentence>_
+**Goal:** Execute **Phase 0 — Foundation & shell** of the migration, in the *new* repository.
 
-### Acceptance criteria
-1. _<concrete user-visible outcome>_
-2. _<...>_
+### Where the work happens
 
-### Files to create / edit
-| Type | File | Content |
-|---|---|---|
-| new | `path/to/file.ts` | _what it does_ |
+Phases 0+ are executed in the **new repo**, not here. This repo is now the behavioural
+reference and the home of the guide. The new repo does not exist yet — creating it is the
+first act of Phase 0.
+
+### Acceptance criteria (Phase 0)
+
+1. `npm install && npm run dev` works on a clean clone — no accounts, no env vars
+2. `npm run quality && npm run test && npm run test:e2e` green in CI, **no secrets** (must
+   pass for fork PRs)
+3. Every route reachable by URL; back/forward works; reload keeps you on the same screen
+4. `TZ='America/Sao_Paulo'` set in Vitest config **and** CI → catches pitfall P-13
+5. CI checks in place: i18n key parity, no `.skip`/`.only`, JSX literal lint
+
+Full checklist: `docs/migration/05-phase-plan.md` → Phase 0.
 
 ### Closed decisions
-- _<choice + reasoning>_
 
-### Open decisions
-- _<question to ask the user before coding>_
+- **Vite + React + TanStack Router**, not Next.js — the old app is 89/91 `'use client'`, uses
+  no SSR, and carries hydration workarounds for a server render that produces nothing (ADR-001)
+- **Not Svelte** — would convert a migration into a rewrite, discards the one layer that ports
+  for free (shadcn/Radix/recharts/dnd-kit), and is the weakest ground for AI-executed work
+- **Local-first, no cloud abstraction until cloud exists** (ADR-003) — the old 17-method
+  `StorageAdapter` has 15 no-op stubs in local mode
+- **Money as integer cents** (ADR-005)
+- **Docs in English**; Portuguese stays a product language via `pt.json`, not a code language
+- Cloud sync is **Phase 10 and blocked** pending a design doc answering 7 listed questions
+
+### Open decisions (ask the user before coding)
+
+- New repo name / brand identity — not yet chosen
+- Whether the redesign introduces new screens beyond the 6 existing views
+- Currency: ship a real currency setting, or hardcode BRL honestly? (F-14)
+- Whether multi-user collaboration stays in scope at all (it caps at 2 members today)
 
 ---
 
-## 📁 Active architecture
+## 📁 Active architecture (this repo — the reference implementation)
 
-- **Stack:** _<frameworks, libraries, runtime>_
-- **Key tables / modules:** _<list>_
-- **Patterns:** _<conventions enforced project-wide>_
+- **Stack:** Next.js 16 App Router, React 19, TypeScript, Tailwind v4, shadcn/ui, Zustand +
+  Immer, next-intl, recharts, AWS Amplify Gen 2 (optional cloud mode)
+- **Runtime source of truth:** `lib/expense-store.ts` (1,887 lines, 56 store members)
+- **Key modules:** `lib/expense-store.ts`, `lib/adapters/`, `lib/write-queue.ts`,
+  `lib/migrations.ts`, `lib/goal-utils.ts`, `lib/formatters.ts`, `messages/{en,pt}.json`
+- **Patterns:** adapter registry for storage/auth; localStorage write queue for cloud sync;
+  month keys `YYYY-MM`; categories as i18n keys with `customLabel` override for custom ones
 
 ---
 
 ## ⚠️ External blockers (don't block coding)
 
-- _<env vars, secrets, external accounts, manual steps>_
+- New repository not yet created (needs the brand decision first)
+- `node_modules` is not installed in the remote session container — `npm run quality` and
+  `npm test` cannot run here without `npm ci` first
 
 ---
 
 ## 🔧 Useful commands
 
 ```bash
-# add the most-used commands here so the next session has them ready
+npm run quality          # typecheck + lint + format:check — run before committing
+npm run test             # Vitest
+npm run test:coverage    # enforces 75% (but see pitfall P-24 — the threshold is misleading)
+npm run test:e2e         # Playwright
+
+# format the migration docs with the repo's own style (no tailwind plugin needed)
+npx prettier@3.8.1 --no-config --no-semi --single-quote --print-width 100 \
+  --tab-width 2 --trailing-comma es5 --arrow-parens always --bracket-spacing \
+  --end-of-line lf --write "docs/migration/*.md"
 ```
 
 ---
 
 ## 📚 References (read IF needed)
 
+- `docs/migration/` — **the migration spec; start at README.md**
 - `.wolf/cerebrum.md` — User Preferences + Do-Not-Repeat + Decision Log
 - `.wolf/anatomy.md` — token-efficient file index
 - `.wolf/buglog.json` — known bugs + fixes

--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -948,6 +948,10 @@
   exit criteria. Phase 10 (cloud) blocked pending design doc (~3085 tok)
 - `06-quality-bar.md` — Definition of done, test layers, pitfall regression tests, i18n and UI
   rules, PR checklist, anti-pattern table (~2208 tok)
+- `07-agent-tooling.md` — Agent toolchain for the new repo, organised as "a skill advises, a
+  hook enforces". 5 layers: enforcement (hooks/lint/CI), context+tasks (OpenWolf, kanban-md,
+  Ponytail), design-system enforcement, visual verification (Playwright MCP), TDD policy
+  (TDD in domain/, test-after in UI). Includes a what-NOT-to-install list (~2400 tok)
 
 ## e2e/
 

--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -929,6 +929,26 @@
 - `e2e-best-practices.md` — Diretrizes e Boas Práticas para Testes E2E (Playwright) (~680 tok)
 - `migration-cloud-workspace.md` — Plano de Migração: Cloud-Only + Workspace (~3112 tok)
 
+## docs/migration/
+
+> Guide for rebuilding Tempest as a new clean open-source app (new brand, same features).
+> Written for AI-executed incremental migration. Entry point is README.md.
+
+- `README.md` — Index, the three rules, per-session protocol. Read first, every session (~1105 tok)
+- `01-target-architecture.md` — 7 ADRs: Vite+React SPA over Next.js, views→routes, local-first
+  with no cloud abstraction, store split by domain, money as integer cents, enforced i18n,
+  OSS day zero. Includes dependency keep/add/drop table (~3576 tok)
+- `02-feature-inventory.md` — 15 features (F-01..F-15) with behaviour, edge cases, required
+  changes, old-code refs and pitfall links. F-15 (cloud) is deferred (~5337 tok)
+- `03-domain-model.md` — Canonical types, branded primitives, rule-based recurrence model,
+  store shape, 10 invariants, old→new import map incl. recurrence reconstruction (~2634 tok)
+- `04-pitfalls.md` — 24 verified defects (P-01..P-24) with evidence, line refs and required
+  behaviour. P-13/P-21/P-10 are live wrong-number bugs (~5365 tok)
+- `05-phase-plan.md` — Living state. Phases 0-10, dependency order, per-phase checklists and
+  exit criteria. Phase 10 (cloud) blocked pending design doc (~3085 tok)
+- `06-quality-bar.md` — Definition of done, test layers, pitfall regression tests, i18n and UI
+  rules, PR checklist, anti-pattern table (~2208 tok)
+
 ## e2e/
 
 - `credit-cards.spec.ts` — Declares toRemove (~3779 tok)

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -1,4 +1,65 @@
 {
   "version": 1,
-  "bugs": []
+  "bugs": [
+    {
+      "id": "bug-001",
+      "timestamp": "2026-07-26T13:00:00Z",
+      "error_message": "Dashboard chart month labels are off by one month, and the Monthly view 'vs previous month' figure compares against two months ago, in any negative-offset timezone (e.g. America/Sao_Paulo).",
+      "file": "components/expense/dashboard-view.tsx:77-78, components/expense/monthly-view.tsx:98-100",
+      "root_cause": "new Date('YYYY-MM-01') parses a date-only ISO string as UTC per ECMA-262, while toLocaleDateString and getMonth()/getFullYear() read local time. In UTC-3 the local date falls on the last day of the previous month. Reproduced: label for 2026-07 renders 'jun.'; previousMonth('2026-07') returns '2026-05'. The store's own helpers (getMonthDiff, getMonthFromOffset) are correct because they use the local constructor new Date(y, m-1, 1).",
+      "fix": "NOT FIXED IN THIS REPO — documented as pitfall P-13 in docs/migration/04-pitfalls.md. Required fix: never construct a Date from a string; parse to numeric parts and use new Date(year, month - 1, day). Run the test suite under TZ='America/Sao_Paulo' so it cannot regress.",
+      "tags": ["timezone", "date-parsing", "utc", "dashboard", "wrong-numbers", "P-13"],
+      "related_bugs": ["bug-002"],
+      "occurrences": 1,
+      "last_seen": "2026-07-26T13:00:00Z"
+    },
+    {
+      "id": "bug-002",
+      "timestamp": "2026-07-26T13:00:00Z",
+      "error_message": "Month-over-month expense change percentage is inflated for any user with an active installment plan.",
+      "file": "components/expense/monthly-view.tsx:102-118",
+      "root_cause": "The current month's total includes installments (fixed + variable + installmentsTotal, lines 115-118) while the previous month's baseline excludes them (lines 102-105). The percentage divides an installment-inclusive number by an installment-exclusive one.",
+      "fix": "NOT FIXED IN THIS REPO — documented as pitfall P-21 in docs/migration/04-pitfalls.md. Required fix: one monthExpenseTotal(month) function in the domain layer, called for both sides of the comparison. Regression test: identical months containing installments must report 0% change.",
+      "tags": ["calculation", "installments", "wrong-numbers", "monthly-view", "P-21"],
+      "related_bugs": ["bug-001", "bug-003"],
+      "occurrences": 1,
+      "last_seen": "2026-07-26T13:00:00Z"
+    },
+    {
+      "id": "bug-003",
+      "timestamp": "2026-07-26T13:00:00Z",
+      "error_message": "Installments are never counted under the 'installment' category — they all fall into 'other' in the dashboard pie chart, the category averages grid, and the monthly category breakdown.",
+      "file": "lib/expense-store.ts:501-505",
+      "root_cause": "mapInstallmentsToExpenses defaults its categoryId parameter to the Portuguese string 'parcelamento'. That ID was renamed to 'installment' by the v1->v2 migration (lib/migrations.ts:51) and DEFAULT_CATEGORIES defines 'installment' (lib/expense-store.ts:191). No category with ID 'parcelamento' exists post-migration, so every projected installment falls through the category fallback to SYSTEM_CATEGORY_ID. Both call sites (dashboard-view.tsx:114, monthly-view.tsx:121) use the default.",
+      "fix": "NOT FIXED IN THIS REPO — documented as pitfall P-10 in docs/migration/04-pitfalls.md. Required fix: no magic-string defaults for IDs; reference the exported constant and make the parameter required so a rename cannot leave a stale literal behind.",
+      "tags": ["categories", "installments", "migration-drift", "magic-string", "wrong-numbers", "P-10"],
+      "related_bugs": ["bug-002"],
+      "occurrences": 1,
+      "last_seen": "2026-07-26T13:00:00Z"
+    },
+    {
+      "id": "bug-004",
+      "timestamp": "2026-07-26T13:00:00Z",
+      "error_message": "A user with the app in English cannot delete their data. They follow the instruction 'Type DELETE ALL', type it exactly, and the confirm button stays disabled with no explanation.",
+      "file": "components/expense/settings-view.tsx:102, components/expense/settings-view.tsx:315",
+      "root_cause": "The confirmation gate compares against the hardcoded Portuguese literal 'DELETAR TUDO', while the instruction and placeholder shown to the user come from i18n — messages/en.json renders them as 'Type DELETE ALL'. The compared phrase and the requested phrase come from different sources.",
+      "fix": "NOT FIXED IN THIS REPO — documented as pitfall P-05 in docs/migration/04-pitfalls.md. Required fix: any phrase that is compared must come from the same message catalogue that instructs the user. Better still, drop the typed-phrase gate in favour of requiring an export first. Regression test: the destructive-confirmation E2E flow must pass in both locales.",
+      "tags": ["i18n", "settings", "blocked-user", "data-deletion", "P-05"],
+      "related_bugs": ["bug-005"],
+      "occurrences": 1,
+      "last_seen": "2026-07-26T13:00:00Z"
+    },
+    {
+      "id": "bug-005",
+      "timestamp": "2026-07-26T13:00:00Z",
+      "error_message": "'Delete all data' does not delete custom categories or credit cards, although the confirmation dialog explicitly lists both as things that will be permanently deleted.",
+      "file": "lib/expense-store.ts:1706-1715",
+      "root_cause": "deleteAllData resets only monthlyData, installments, notes, goals, currentMonth and currentYear. The categories and creditCards slices are left untouched, while the dialog renders ui.settings.allCategories and ui.settings.allCreditCards among the items to be destroyed (settings-view.tsx:291-294).",
+      "fix": "NOT FIXED IN THIS REPO — documented as pitfall P-22 in docs/migration/04-pitfalls.md. Required fix: reset every store slice to its initial state (categories back to the 11 defaults, cards empty), with a test asserting the post-condition field by field so copy and code cannot drift apart again.",
+      "tags": ["settings", "data-deletion", "copy-vs-behaviour", "P-22"],
+      "related_bugs": ["bug-004"],
+      "occurrences": 1,
+      "last_seen": "2026-07-26T13:00:00Z"
+    }
+  ]
 }

--- a/.wolf/buglog.json
+++ b/.wolf/buglog.json
@@ -60,6 +60,18 @@
       "related_bugs": ["bug-004"],
       "occurrences": 1,
       "last_seen": "2026-07-26T13:00:00Z"
+    },
+    {
+      "id": "bug-006",
+      "timestamp": "2026-07-26T13:10:00Z",
+      "error_message": "npm error code EUSAGE — `npm ci` can only install packages when your package.json and package-lock.json are in sync. Invalid: lock file's @smithy/uuid@1.3.10 does not satisfy @smithy/uuid@1.3.14. Invalid: lock file's @smithy/core@3.29.5 does not satisfy @smithy/core@3.30.0",
+      "file": "package-lock.json",
+      "root_cause": "Every requirement on @smithy/core and @smithy/uuid in the tree is a caret range (^3.22.0, ^3.23.2, ^1.1.0 etc.) coming from transitive AWS SDK / Amplify dependencies. The lock pinned 3.29.5 and 1.3.10, but newer releases (3.30.0, 1.3.14) satisfy those ranges, so npm re-resolves and rejects the lock as out of sync. Time-dependent, not commit-dependent: main last passed CI on 2026-07-19 at the same base commit (c2bc8989) and the failure appeared later without any repo change. Reproduced on a clean checkout, so it was not caused by the branch it surfaced on.",
+      "fix": "Regenerated the lock with the procedure documented in CLAUDE.md: `npm install --package-lock-only --ignore-scripts`. Result was minimal — package.json untouched, zero packages added or removed, only the two transitive bumps (@smithy/core 3.29.5->3.30.0, @smithy/uuid 1.3.10->1.3.14), 7 insertions / 7 deletions. Verified after the change: npm ci --ignore-scripts exit 0, npm run typecheck pass, npm run lint pass, npm run format:check pass, npx vitest run 27 files / 324 tests all passing.",
+      "tags": ["ci", "npm", "package-lock", "EUSAGE", "aws-sdk", "smithy", "dependency-drift"],
+      "related_bugs": [],
+      "occurrences": 1,
+      "last_seen": "2026-07-26T13:10:00Z"
     }
   ]
 }

--- a/.wolf/cerebrum.md
+++ b/.wolf/cerebrum.md
@@ -2,22 +2,109 @@
 
 > OpenWolf's learning memory. Updated automatically as the AI learns from interactions.
 > Do not edit manually unless correcting an error.
-> Last updated: 2026-07-18
+> Last updated: 2026-07-26
 
 ## User Preferences
 
-<!-- How the user likes things done. Code style, tools, patterns, communication. -->
+- [2026-07-26] Speaks Portuguese; wants **documentation and code in English** (open-source
+  audience). Portuguese stays a product language via `pt.json`, not a code language.
+- [2026-07-26] When asked for a technical opinion ("should we move to Svelte?"), wants a
+  **direct recommendation with reasoning grounded in this codebase**, not a survey of options.
+  Measure the codebase first, then recommend.
+- [2026-07-26] Values incremental, phased delivery over big-bang. Explicitly wants every
+  improvement (i18n, tests, refactors) made **during** the migration of that part — never
+  deferred to a cleanup pass.
+- [2026-07-26] Wants quality guardrails that are **enforced, not aspirational**, and explicitly
+  asked for this "sem complicar" — prefer a few machine-checked rules over long checklists.
+- [2026-07-26] Documents are meant to be consumed by **AI agents across many sessions**, so
+  they need an index, a per-session read path, and living state — not prose essays.
 
 ## Key Learnings
 
-- **Project:** tempest
-- **Description:** Personal expense management app — track income, expenses, investments, and savings. Runs locally with zero config or syncs to AWS Amplify for shared workspaces.
+- **Project:** tempest — personal expense management (income, expenses, investments, savings).
+- **Being replaced** by a new open-source app: new brand, redesigned UI, same features.
+  Spec lives in `docs/migration/`; start at its `README.md`.
+- **Architecture reality vs intent:** despite being a Next.js App Router app, 89 of 91
+  component files are `'use client'`. Only `app/layout.tsx` and `app/brand/page.tsx` render on
+  the server. It is a SPA wearing a Next.js costume — and it pays for that with hydration
+  workarounds (`suppressHydrationWarning`, `mounted` gates, `isHydrated` gates).
+- **Navigation is `useState`, not routes.** All 6 views live behind `/` in `app/page.tsx`, so
+  there are no deep links and the back button exits the app. `/settings` confusingly exists as
+  a real route *as well*.
+- **Category labels are dual-sourced and this is load-bearing:** default categories have no
+  stored label — their `id` IS the i18n key, so they translate. Custom categories store
+  `customLabel` and never translate. Resolution is always
+  `customLabel ?? t('categories.' + id)`. Do not flatten this.
+- **Recurrence is materialised, not modelled.** One recurring income writes 25 rows (current
+  month + 24). That single decision causes the 24-month cliff, the 25-mutation cloud fan-out,
+  and most of the store's complexity.
+- **The i18n setup is complete and largely unused.** 502 keys at near-parity across en/pt,
+  while `dashboard-view.tsx` hardcodes every string in Portuguese and all 36 `formatCurrency`
+  call sites pass no locale. Infrastructure without enforcement decays.
+- **Coverage config hides the risky code.** `vitest.config.ts` excludes `migrations.ts`,
+  `write-queue.ts`, `sync-store.ts`, `workspace-client.ts` and all Amplify adapters from the
+  75% threshold — i.e. everything most likely to be wrong.
+- `lib/validations.ts` exists, exports 5 zod schemas, and is imported by **zero** files. Always
+  grep for importers before trusting that a module is live.
+- `lib/goal-utils.ts` is the one genuinely clean module — pure, testable, no side effects. It
+  is the model for what the new `domain/` layer should look like.
 
 ## Do-Not-Repeat
 
-- [2026-07-18] NUNCA subestime o impacto de alterações na interface (como mudanças simples de texto ou componentes). O projeto possui uma suíte extensa de testes unitários e E2E (Playwright) que cobrem praticamente todos os fluxos. Qualquer modificação nos componentes visuais ou textos pode e vai quebrar seletores de testes.
-- [2026-07-18] SEMPRE trate processos obrigatórios (como linter e testes passando) como verdades absolutas. Não pergunte ao usuário se deve ou não consertar o código para que o linter ou testes passem. Se houver falhas, corrija ativamente.
+- [2026-07-18] NUNCA subestime o impacto de alterações na interface (como mudanças simples de
+  texto ou componentes). O projeto possui uma suíte extensa de testes unitários e E2E
+  (Playwright) que cobrem praticamente todos os fluxos. Qualquer modificação nos componentes
+  visuais ou textos pode e vai quebrar seletores de testes.
+- [2026-07-18] SEMPRE trate processos obrigatórios (como linter e testes passando) como
+  verdades absolutas. Não pergunte ao usuário se deve ou não consertar o código para que o
+  linter ou testes passem. Se houver falhas, corrija ativamente.
+- [2026-07-26] **NEVER `new Date(dateOnlyString)`.** Date-only ISO strings parse as UTC per
+  ECMA-262, so in `America/Sao_Paulo` (this app's default market) they render as the previous
+  day — and therefore the previous *month* for `YYYY-MM-01`. Reproduced: dashboard labels off
+  by one, `previousMonth('2026-07')` returns `2026-05`. Always use
+  `new Date(year, month - 1, day)`. Run tests under a non-UTC `TZ`.
+- [2026-07-26] **Never compute the same total two different ways.** `monthly-view.tsx`
+  includes installments in the current month's total but excludes them from the previous
+  month's, so the month-over-month percentage is wrong for anyone with an installment plan.
+  One function, called twice.
+- [2026-07-26] **Never use a magic-string default for an ID.** `mapInstallmentsToExpenses`
+  defaults `categoryId` to `'parcelamento'`, which the v1→v2 migration renamed to
+  `'installment'`. Every installment has silently been counted as `other` ever since.
+- [2026-07-26] **Never compare against a hardcoded phrase that has a translated counterpart.**
+  `settings-view.tsx` gates delete-all on `'DELETAR TUDO'` while the English UI instructs the
+  user to type `DELETE ALL` — English users cannot delete their data at all.
+- [2026-07-26] **Never `.sort()` a value from a store selector.** `expense-form.tsx` sorts the
+  categories array in place during render, mutating store state outside `set()`.
+- [2026-07-26] **Do not build an abstraction for a backend that is not there yet.** The
+  17-method `StorageAdapter` is shaped entirely around Amplify; its local implementation has
+  15 methods that just `return Promise.resolve()`.
+- [2026-07-26] **Never leave `test.skip` in a committed spec.** All three income-replication
+  E2E tests are skipped — the riskiest logic in the app — while the file still looks like
+  coverage in a directory listing.
+- [2026-07-26] Before claiming a module is used, `grep` for its importers. Before claiming a
+  bug exists, reproduce it.
 
 ## Decision Log
 
-<!-- Significant technical decisions with rationale. Why X was chosen over Y. -->
+- [2026-07-26] **Vite + React 19 + TanStack Router (SPA/PWA) over Next.js** for the new app.
+  Evidence: 89/91 files are client components, zero server actions, and the only server APIs
+  used are `generateMetadata` and next-intl's cookie read. Dropping Next deletes an entire
+  class of hydration bug rather than reimplementing the workarounds. shadcn/Radix/recharts/
+  dnd-kit port unchanged; only routing, i18n provider, and metadata change. (ADR-001)
+- [2026-07-26] **Rejected Svelte 5 + SvelteKit.** Three reasons: (1) it converts a migration
+  into a rewrite by discarding the UI layer that ports for free; (2) Svelte 5 runes are recent
+  enough that agents regress to Svelte 4 syntax, which is a real risk to an AI-executed
+  migration held to an absolute quality bar; (3) none of this codebase's actual problems are
+  React's fault — they are a god store, a leaky adapter, and unenforced i18n.
+- [2026-07-26] **Local-first first; cloud is a later, optional layer** (user's choice). No
+  storage abstraction exists in Phase 1. Sync is designed against a *finished* local app, so
+  the requirements are known rather than guessed. (ADR-003)
+- [2026-07-26] **Money becomes integer cents.** The old app stores floats and hides the drift
+  by formatting with `maximumFractionDigits: 0`. (ADR-005)
+- [2026-07-26] **Recurrence becomes a rule, not materialised rows.** Removes the 24-month
+  cliff, the 25-writes-per-action fan-out, and most of the store's size. (03-domain-model)
+- [2026-07-26] **Views become real routes** with month/year as URL search params, so deep
+  links, the back button, and reload-in-place all work. (ADR-002)
+- [2026-07-26] Migration docs in `docs/migration/`, in **English**, structured for AI
+  consumption: numbered docs, stable IDs (F-xx features, P-xx pitfalls, ADR-xxx decisions),
+  and `05-phase-plan.md` as the single living state file.

--- a/.wolf/cerebrum.md
+++ b/.wolf/cerebrum.md
@@ -111,6 +111,14 @@
   cliff, the 25-writes-per-action fan-out, and most of the store's size. (03-domain-model)
 - [2026-07-26] **Views become real routes** with month/year as URL search params, so deep
   links, the back button, and reload-in-place all work. (ADR-002)
+- [2026-07-26] **Agent toolchain for the new repo decided** (`07-agent-tooling.md`), on the
+  principle "a skill advises, a hook enforces". Enforcement (hooks + lint + CI) installs
+  before any convenience tool. TDD applies to `domain/` only — pure functions with a spec
+  that already exists in `06` — and never to UI, where the design is discovered visually.
+  Keep OpenWolf but force `STATUS.md` updates with a `Stop` hook; kanban-md only if agents
+  run in parallel; Ponytail only with `domain/` and tests excluded, since "write less code"
+  fights the quality bar. Playwright MCP over Chrome DevTools MCP — same browser stack as
+  the existing E2E suite.
 - [2026-07-26] Migration docs in `docs/migration/`, in **English**, structured for AI
   consumption: numbered docs, stable IDs (F-xx features, P-xx pitfalls, ADR-xxx decisions),
   and `05-phase-plan.md` as the single living state file.

--- a/.wolf/cerebrum.md
+++ b/.wolf/cerebrum.md
@@ -83,6 +83,12 @@
   coverage in a directory listing.
 - [2026-07-26] Before claiming a module is used, `grep` for its importers. Before claiming a
   bug exists, reproduce it.
+- [2026-07-26] **A red CI on a docs-only PR is probably not the PR.** `npm ci` failed with
+  EUSAGE on transitive `@smithy/*` caret ranges. Check whether the failure reproduces on a
+  clean checkout of the base commit *before* assuming your diff caused it — here the base had
+  last passed a week earlier and the drift came from the registry, not the repo. Fix with
+  `npm install --package-lock-only --ignore-scripts` (per CLAUDE.md), never a plain
+  `npm install`.
 
 ## Decision Log
 

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -13,6 +13,8 @@
 | 12:50 | Wrote migration guide | docs/migration/*.md (7 files) | ~23k tokens of spec; all cross-refs validated | ~25k |
 | 13:05 | Formatted docs with repo prettier style | docs/migration/*.md | Clean; embedded code matches semi:false/singleQuote | ~1k |
 | 13:10 | Updated OpenWolf context | .wolf/{STATUS,anatomy,cerebrum,memory}.md | STATUS.md filled (was an empty template) | ~3k |
+| 13:12 | Opened draft PR #18 | — | CI red on all 3 jobs at `npm ci` | ~2k |
+| 13:15 | Diagnosed + fixed lock drift (EUSAGE, @smithy/*) | package-lock.json | 7+/7-; typecheck+lint+format+324 tests pass | ~6k |
 
 ### Session summary
 

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -15,10 +15,11 @@
 | 13:10 | Updated OpenWolf context | .wolf/{STATUS,anatomy,cerebrum,memory}.md | STATUS.md filled (was an empty template) | ~3k |
 | 13:12 | Opened draft PR #18 | — | CI red on all 3 jobs at `npm ci` | ~2k |
 | 13:15 | Diagnosed + fixed lock drift (EUSAGE, @smithy/*) | package-lock.json | 7+/7-; typecheck+lint+format+324 tests pass | ~6k |
+| 14:20 | Researched agent toolchain (skills/MCP) for the new repo | docs/migration/07-agent-tooling.md | 5-layer stack; TDD scoped to domain/ only | ~12k |
 
 ### Session summary
 
-Produced `docs/migration/` — a 7-document guide for rebuilding Tempest as a new clean
+Produced `docs/migration/` — an 8-document guide for rebuilding Tempest as a new clean
 open-source app (new brand, same features), written to be executed incrementally by AI agents.
 
 Key outputs: 7 closed ADRs, 15 mapped features, 24 evidence-backed pitfalls, an 11-phase plan

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -2,3 +2,36 @@
 
 > Chronological action log. Hooks and AI append to this file automatically.
 > Old sessions are consolidated by the daemon weekly.
+
+## Session: 2026-07-26 12:17
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 12:20 | Mapped codebase: store, adapters, amplify schema, i18n, components, tests | read-only | 1887-line store + 56 members; 89/91 files `'use client'` | ~45k |
+| 12:35 | Verified suspected defects via grep + node repro | lib/, components/ | 24 pitfalls confirmed with line evidence | ~8k |
+| 12:40 | Reproduced timezone bug under TZ=America/Sao_Paulo | scratchpad/dt.mjs | Dashboard months off by one; prev-month off by two | ~1k |
+| 12:50 | Wrote migration guide | docs/migration/*.md (7 files) | ~23k tokens of spec; all cross-refs validated | ~25k |
+| 13:05 | Formatted docs with repo prettier style | docs/migration/*.md | Clean; embedded code matches semi:false/singleQuote | ~1k |
+| 13:10 | Updated OpenWolf context | .wolf/{STATUS,anatomy,cerebrum,memory}.md | STATUS.md filled (was an empty template) | ~3k |
+
+### Session summary
+
+Produced `docs/migration/` — a 7-document guide for rebuilding Tempest as a new clean
+open-source app (new brand, same features), written to be executed incrementally by AI agents.
+
+Key outputs: 7 closed ADRs, 15 mapped features, 24 evidence-backed pitfalls, an 11-phase plan
+with exit criteria, and a definition of done.
+
+Three **live user-facing bugs** were found and reproduced during mapping, all still present in
+this repo (documented as P-13, P-21, P-10 — not fixed here, this session was spec-only):
+
+1. **P-13** — `new Date('2026-07-01')` parses as UTC. In `America/Sao_Paulo` every dashboard
+   chart month label is off by one, and the Monthly view's "vs previous month" reads **two**
+   months back.
+2. **P-21** — month-over-month expense change divides an installment-inclusive total by an
+   installment-exclusive one.
+3. **P-10** — `mapInstallmentsToExpenses` defaults to category `'parcelamento'`, renamed to
+   `'installment'` by the v1→v2 migration, so every installment is counted as `other`.
+
+Also found: English users literally cannot delete their data (**P-05** — gate compares
+`'DELETAR TUDO'` while the English UI says to type `DELETE ALL`).

--- a/docs/migration/01-target-architecture.md
+++ b/docs/migration/01-target-architecture.md
@@ -1,0 +1,418 @@
+# 01 — Target Architecture
+
+Decisions are recorded ADR-style: context, decision, consequences. They are **closed**
+unless this document says otherwise. Do not relitigate them mid-migration.
+
+---
+
+## ADR-001 — Vite + React SPA, not Next.js
+
+### Context
+
+The old app is built on Next.js 16 App Router, but measured against the codebase it does
+not use it:
+
+| Measurement                             | Value                                                        |
+| --------------------------------------- | ------------------------------------------------------------ |
+| Files in `app/`, `components/`, `lib/`  | 131                                                          |
+| Files marked `'use client'`             | 91                                                           |
+| Components that render on the server    | **2** (`app/layout.tsx`, `app/brand/page.tsx`)               |
+| Server-only APIs used in the entire app | `generateMetadata`, next-intl's `cookies()`/`headers()` read |
+| Server actions / route handlers         | 0                                                            |
+
+The app is a single-page client application with an SSR shell bolted on. The cost of that
+shell is visible as scar tissue throughout the code:
+
+- `lib/expense-store.ts:520` — `shouldUseSampleData()` returns `false` when
+  `typeof window === 'undefined'`, with the comment _"prevents hydration mismatch"_.
+- `app/layout.tsx:90` — `<html suppressHydrationWarning>`.
+- `components/theme-toggle.tsx:11-17` — a `mounted` state gate that renders a placeholder
+  on the first pass purely to avoid a hydration mismatch.
+- `components/expense/dashboard-view.tsx:51-55` — an `isHydrated` state gate that blanks the
+  entire dashboard behind a "Carregando..." card on first render, for the same reason.
+
+That last one is the clearest signal: the app's main screen is hidden from the server
+render to stop the server and client disagreeing. The SSR pass produces nothing usable.
+
+### Decision
+
+Build the new app as **Vite + React 19 + TanStack Router**, shipped as an SPA/PWA.
+
+### Consequences
+
+**What carries over unchanged.** Everything visual and interactive is framework-agnostic
+with respect to _Next_, not React: shadcn/ui components, Radix primitives, Tailwind v4,
+recharts, dnd-kit, react-hook-form, zod, lucide icons. These are copied and restyled for
+the new brand, not re-sourced.
+
+**What changes, and how much work each is.**
+
+| Concern          | Old                                                 | New                                                   | Effort                                                   |
+| ---------------- | --------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------- |
+| Routing          | `useState<ActiveView>` in `app/page.tsx`            | TanStack Router file routes                           | Small — see ADR-002                                      |
+| i18n             | `next-intl`                                         | `use-intl` (same core library, same message format)   | Mechanical — `messages/*.json` carry over byte-identical |
+| Locale detection | `proxy.ts` middleware + `x-next-intl-locale` header | `localStorage` + `navigator.language`                 | Simplification — delete `proxy.ts`                       |
+| Metadata         | `generateMetadata()`                                | static `index.html` + a small `useDocumentTitle` hook | Small                                                    |
+| Fonts            | `next/font/google`                                  | self-hosted via `@fontsource` or a `<link>`           | Small                                                    |
+| Analytics        | `@vercel/analytics/next`                            | `@vercel/analytics` (framework-agnostic entry)        | Trivial                                                  |
+
+**What is gained.**
+
+- An entire class of bug becomes unrepresentable. Every workaround listed above is deleted
+  rather than reimplemented.
+- Vitest runs on the project's own Vite config — one build pipeline, not two.
+- PWA/offline is first-class (`vite-plugin-pwa`), which is the correct shape for a
+  local-first personal finance app opened on a phone.
+- Faster dev loop and a substantially smaller dependency surface for an open-source project
+  that wants outside contributors.
+
+**What is given up.** Server rendering, server actions, and Next's image optimisation —
+none of which the app used. If cloud sync later needs a server endpoint, it is added as a
+separate small service, not by reintroducing a framework.
+
+> `use-intl` is the runtime `next-intl` is built on, by the same author. Message files,
+> the ICU syntax, and the `useTranslations()` API are the same. This is a swap of the
+> provider and the locale-resolution layer, not of the i18n system.
+
+---
+
+## ADR-002 — Views become routes
+
+### Context
+
+`app/page.tsx:17` holds the entire navigation model:
+
+```tsx
+const [activeView, setActiveView] = useState<ActiveView>('dashboard')
+...
+{activeView === 'dashboard' && <DashboardView />}
+{activeView === 'monthly'   && <MonthlyView />}
+{activeView === 'categories'&& <CategoriesView />}
+{activeView === 'cards'     && <CreditCardsView />}
+{activeView === 'goals'     && <GoalsView />}
+{activeView === 'settings'  && <SettingsView />}
+```
+
+Six screens live behind one URL (`/`). The consequences are user-visible:
+
+- No deep links. A user cannot bookmark or share Goals.
+- The browser back button exits the app instead of returning to the previous screen.
+- A reload always lands on the Dashboard, discarding where the user was.
+- `/settings` _also_ exists as a real route (`app/settings/page.tsx`), so Settings is
+  reachable two different ways with two different behaviours.
+
+### Decision
+
+Each screen is a real route with a real URL. Selected month and year are **URL search
+params**, not store state.
+
+```
+/                     → redirect to /dashboard
+/dashboard            ?year=2026
+/months/$month        e.g. /months/2026-07
+/categories
+/cards
+/goals
+/goals/$goalId        (the detail sheet becomes addressable)
+/settings
+```
+
+### Consequences
+
+- Back/forward, deep links, reload-in-place, and shareable URLs all work for free.
+- `currentMonth` / `currentYear` leave the store entirely. They are navigation state, and
+  keeping them in a persisted store is what forces `setCurrentMonth` to call
+  `initializeYear` as a side effect (see pitfall **P-06**).
+- TanStack Router's typed params mean an invalid month in the URL is caught at the route
+  boundary, not deep inside a selector.
+- Route-level code splitting comes for free, which matters because recharts is heavy and
+  only the Dashboard needs it.
+
+---
+
+## ADR-003 — Local-first, with no cloud abstraction until cloud exists
+
+### Context
+
+The old app abstracts storage behind `lib/adapters/storage-adapter.ts`: a 17-method
+interface plus a 3-method `CollaborativeStorageAdapter` extension. The interface is shaped
+entirely around AWS Amplify's data model — `workspaceGroup`, `monthlyDataId`,
+`touchWorkspaceActivity`, `createMonthlyData`, cloud-id/local-key translation.
+
+The local implementation (`lib/adapters/local/local-storage-adapter.ts`) is 246 lines, of
+which **15 of the 17 methods are stubs**:
+
+```ts
+createCategory(_localKey: string, _data: CategoryInput): Promise<void> {
+  return Promise.resolve()
+}
+```
+
+The local adapter does not persist anything — Zustand's `persist` middleware already does.
+`fetchWorkspaceData()` reads the Zustand store and reshapes it into Amplify's wire format
+so that `loadWorkspace()` can immediately reshape it back. The abstraction costs 246 lines
+of local code, ~170 lines of type definitions, and buys nothing in local mode.
+
+There is a second cost. Because the store must serve both modes, every mutation in
+`lib/expense-store.ts` carries a cloud tail:
+
+```ts
+const { workspaceGroup, workspaceId } = useSyncStore.getState()
+if (workspaceGroup && workspaceId) {
+  enqueue({
+    model: 'Expense',
+    operation: 'create',
+    data: {
+      /* 9 fields */
+    },
+  })
+  enqueue({ model: 'Workspace', operation: 'update', data: { id: workspaceId } })
+}
+```
+
+This block, in variations, appears **19 times** and is a large part of why the store is
+1,887 lines. It is also where the sync bugs live (**P-01**, **P-02**, **P-03**).
+
+### Decision
+
+Phase 1 has **no storage abstraction at all**. The store persists to IndexedDB via a thin
+`persistence` module. There is no `StorageAdapter`, no `SyncStore`, no `write-queue`, no
+`workspaceGroup` on any type.
+
+Cloud sync is designed and added in a later phase (see `05`), against a finished and tested
+local app — at which point the real requirements are known instead of guessed.
+
+### Consequences
+
+- The store shrinks dramatically. Business logic stops being interleaved with wire-format
+  translation.
+- Domain types lose their cloud contamination (`workspaceGroup`, `monthlyDataId`,
+  `cardId`/`card` duality, `noteCreatedAt` vs `createdAt`). See `03`.
+- When cloud sync is designed, it is designed as a **sync layer over a local log**, not as
+  a per-mutation RPC fan-out. The old approach enqueues one mutation per affected record,
+  which means adding a recurring expense enqueues 25 creates plus a workspace touch
+  (**P-04**).
+- Nothing about the local app needs to change when cloud arrives, because sync observes
+  the store rather than being called from inside it.
+
+**Persistence choice: IndexedDB, not localStorage.** The old app stores everything as a
+single JSON blob under the `expense-store` key. A user with three years of data holds
+~36 months × (incomes + fixed + variable + savings) in one string that is parsed and
+re-serialised on **every** mutation. localStorage is also synchronous and capped around
+5 MB. Use IndexedDB (via `idb-keyval` or Dexie) with the Zustand `persist` middleware's
+custom storage. Keep the write path async and debounced.
+
+---
+
+## ADR-004 — The store is split by domain
+
+### Context
+
+`lib/expense-store.ts` is 1,887 lines and holds: domain types, default data, a seeded
+sample-data generator, date math, kebab-case normalisation, category management, credit
+card management, income, expenses, recurring propagation, installments, notes, goals,
+savings entries, data deletion, cloud loading, cloud sync-checking, localStorage migration
+wiring, and a re-export of the formatters module.
+
+`ExpenseStore` declares **56 members**. Nothing can be tested, reasoned about, or changed
+in isolation.
+
+### Decision
+
+Split into focused stores plus a pure domain layer:
+
+```
+src/
+  domain/               ← pure functions, zero React, zero storage. 100% unit-testable.
+    money.ts            ← Money type + arithmetic (see ADR-005)
+    month.ts            ← MonthKey type, parsing, offsets, ranges, diffs
+    recurrence.ts       ← recurring group expansion + propagation rules
+    installments.ts     ← schedule computation, occurrence-in-month
+    goals.ts            ← progress, status, monthly-needed  (old lib/goal-utils.ts)
+    categories.ts       ← id normalisation, system-category rules
+  stores/
+    ledger-store.ts     ← monthlyData: incomes, expenses, savings entries
+    catalog-store.ts    ← categories + credit cards (user configuration)
+    planning-store.ts   ← installments, goals, notes
+  persistence/
+    db.ts               ← IndexedDB adapter
+    migrate.ts          ← versioned schema migrations
+```
+
+### Consequences
+
+- `domain/` has no dependencies and no mocking requirements. Recurring propagation and
+  installment scheduling — the two places the old app actually gets things wrong — become
+  directly testable.
+- Stores hold state and orchestrate; they do not compute. Any function longer than a few
+  lines inside a store action belongs in `domain/`.
+- The old store's habit of calling `get()` mid-action to re-read state it just wrote
+  (`lib/expense-store.ts:998-1001` reads `monthlyData`, calls `initializeYear`, then reads
+  `get().monthlyData` again) disappears, because propagation is computed as a pure function
+  and applied once.
+
+**Keep Zustand.** It is the right size for this app and the team knows it. The problem was
+never Zustand; it was putting 56 members in one store. Use `immer` middleware consistently
+— the old store mixes manual spread-copying with Immer-style intent and gets it wrong in
+places (`lib/expense-store.ts:762` mutates `monthData.incomes` through a shallow copy).
+
+---
+
+## ADR-005 — Money is integer cents
+
+### Context
+
+Every amount in the old app is a JavaScript `number` holding a decimal currency value, and
+they are summed freely:
+
+```ts
+month.fixedExpenses.reduce((sum, e) => sum + e.amount, 0)
+```
+
+Meanwhile `lib/formatters.ts:27-28` formats with `minimumFractionDigits: 0` and
+`maximumFractionDigits: 0` — cents are never displayed. The UI therefore hides the
+rounding drift that float arithmetic introduces, rather than preventing it.
+
+The forms compound this: per `CLAUDE.md`, currency inputs use `step="1"` specifically to
+avoid "useless micro-increments", so the app is _already_ de-facto integer-valued while
+storing floats.
+
+### Decision
+
+Store money as **integer cents** (`type Cents = number & { readonly __brand: 'Cents' }`).
+All arithmetic in `domain/money.ts`. Format at the edge only.
+
+### Consequences
+
+- `0.1 + 0.2` problems become impossible. Sums, averages, percentages, and goal progress
+  are exact.
+- Formatting takes `Cents` and produces a string; parsing takes user input and produces
+  `Cents`. Neither is done inline in components.
+- Decide explicitly whether the UI accepts cents. Recommended: **yes** — accept
+  `1.234,56`, store `123456`, display with 2 decimals. The old app's decision to hide cents
+  was a workaround for float drift, not a product choice.
+- Migration from old data multiplies by 100 and rounds once, at import. See `03`.
+
+---
+
+## ADR-006 — i18n is enforced, not encouraged
+
+### Context
+
+The old app has a complete i18n setup — 502 keys, `en.json` and `pt.json` at near-perfect
+parity (2 keys missing from `en`) — and then does not use it in the places that matter:
+
+- `components/expense/dashboard-view.tsx` imports `useTranslations` on line 4 and then
+  hardcodes **every single string in Portuguese**: `"Painel"`, `"Media de Despesas
+Mensais"`, `"Renda vs Despesas"`, `"Poupanca e Investimentos"`, `"Pendencias
+Financeiras"`. The `ui.dashboard.*` keys exist in both message files and are dead.
+- All **36** `formatCurrency` / `formatShortCurrency` call sites pass no locale, so every
+  amount renders as `pt-BR`/`BRL` regardless of language.
+- `components/expense/settings-view.tsx:102` gates destructive confirmation on the literal
+  string `'DELETAR TUDO'` while the English UI instructs the user to type `DELETE ALL`.
+  **An English-language user cannot delete their data.** See **P-05**.
+- Error messages thrown from the store are hardcoded Portuguese
+  (`lib/expense-store.ts:1468`, `1504`, `1527`).
+
+The setup was correct; nothing enforced its use.
+
+### Decision
+
+1. **No user-visible string literal in any component.** Enforced by ESLint
+   (`react/jsx-no-literals` with a curated allowlist for symbols and numerals).
+2. **Message parity is a CI check**, not a review habit. A script diffs the key sets of
+   `en.json` and `pt.json` and fails the build on asymmetry or on keys defined but never
+   referenced.
+3. **Locale reaches formatting through context, not defaults.** `formatCurrency` has no
+   default locale parameter — omitting it is a type error. A `useFormatters()` hook binds
+   the active locale once and components call `format.currency(cents)`.
+4. **Domain and store code never produce user-facing text.** They throw typed errors
+   (`class DuplicateCategoryError extends DomainError`); the UI maps error types to
+   messages.
+
+### Consequences
+
+- The `ui.dashboard.*` keys get used, and dead keys (`totalInvestments`, `investmentRate` —
+  leftovers from the removed investments feature) are deleted.
+- Adding a locale becomes a translation task, not an audit.
+- The `DELETAR TUDO` class of bug cannot recur, because the confirmation phrase comes from
+  the same message file as the instruction that asks for it.
+
+---
+
+## ADR-007 — Open source from day zero
+
+### Context
+
+The old repo is `"private": true` in `package.json`, ships a `LICENSE`, and contains an
+`amplify/` backend directory that only the original author can deploy. A contributor
+cloning it cannot run the cloud half at all, and the local half prints
+`"Amplify not configured — run npx ampx sandbox"` at them from the Settings screen.
+
+### Decision
+
+The new repo is public from the first commit and **fully functional with `npm install &&
+npm run dev`** — no accounts, no cloud, no environment variables.
+
+### Consequences
+
+- No backend directory in the main repo until cloud sync ships; when it does, it is
+  optional and clearly separated, and its absence must never surface in the UI as an error
+  or a disabled control.
+- `README`, `CONTRIBUTING`, `LICENSE`, `CODE_OF_CONDUCT`, and issue/PR templates land in
+  Phase 0, not "later".
+- CI runs on pull requests from forks — which means it cannot depend on secrets.
+- All code comments, identifiers, commit messages, and documentation in **English**.
+  Portuguese remains a first-class _product_ language via `pt.json`; it is not a code
+  language. The old repo mixes both (`// Seção: Preferências` inside
+  `settings-view.tsx:128`, Portuguese error strings in `lib/`).
+
+---
+
+## Dependency decisions
+
+| Keep                                | Why                                          |
+| ----------------------------------- | -------------------------------------------- |
+| React 19, TypeScript (strict)       | Unchanged foundation                         |
+| Tailwind v4, shadcn/ui, Radix       | Ports directly; restyled for the new brand   |
+| Zustand + Immer                     | Right-sized; split by domain per ADR-004     |
+| zod                                 | Keep — but actually use it (see below)       |
+| react-hook-form                     | Keep; pair with zod resolver on every form   |
+| recharts                            | Keep; lazy-load with the Dashboard route     |
+| dnd-kit                             | Keep — used for category and card reordering |
+| date-fns                            | Keep; confine to `domain/month.ts`           |
+| lucide-react                        | Keep                                         |
+| Vitest, Playwright, Testing Library | Keep                                         |
+
+| Add                            | Why                            |
+| ------------------------------ | ------------------------------ |
+| `@tanstack/react-router`       | ADR-002                        |
+| `use-intl`                     | ADR-001 — replaces `next-intl` |
+| `vite`, `@vitejs/plugin-react` | ADR-001                        |
+| `vite-plugin-pwa`              | Offline/installable            |
+| `idb-keyval` or `dexie`        | ADR-003 persistence            |
+
+| Drop                                                                                       | Why                                                                          |
+| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `next`, `next-intl`, `next-themes`                                                         | ADR-001. Theme handling is ~30 lines against `prefers-color-scheme`.         |
+| `aws-amplify`, `@aws-amplify/*`, `aws-cdk-lib`, `constructs`                               | ADR-003 — deferred to the cloud phase                                        |
+| `@dnd-kit` extras, `embla-carousel`, `input-otp`, `react-resizable-panels`, `vaul`, `cmdk` | Audit before porting: several are pulled in only by unused shadcn primitives |
+| `use-sync-external-store`                                                                  | Redundant with React 19                                                      |
+| `autoprefixer`                                                                             | Tailwind v4 handles this                                                     |
+
+> **On `components/ui/`.** The old repo vendors **63** shadcn primitives; the app imports a
+> fraction of them. Port on first use, not wholesale. Every ported primitive must be
+> restyled to the new brand and have at least one render test if it wraps a Radix
+> primitive.
+
+### A note on `zod`
+
+`lib/validations.ts` exists, defines five schemas, and is imported by **zero files** —
+verified by grep across the repo. Forms validate inline instead. The file has drifted so
+far that `installmentSchema` still enumerates a hardcoded card list
+(`'nubank_pri' | 'nubank_ma' | 'mercadopago' | 'itau'`) from before credit cards became
+user-configurable, and all its messages are hardcoded Portuguese.
+
+In the new app: one schema per form, colocated with the form, wired through
+`@hookform/resolvers/zod`, with messages resolved from i18n keys rather than literals. A
+schema that is not wired to a resolver must not be written.

--- a/docs/migration/02-feature-inventory.md
+++ b/docs/migration/02-feature-inventory.md
@@ -1,0 +1,635 @@
+# 02 — Feature Inventory
+
+The behavioural specification. Each feature lists **what it must do**, the **edge cases**
+that are easy to miss, the **old-code reference** (to read, not to copy), and the
+**pitfalls** that apply.
+
+Read only the section for the feature you are migrating.
+
+**Legend:** `→ P-xx` links to an entry in [`04-pitfalls.md`](./04-pitfalls.md). Every linked
+pitfall must be verified as _not reproduced_ before the feature is considered done.
+
+---
+
+## F-01 · Month & Year Navigation
+
+**Old reference:** `components/expense/month-selector.tsx`, `year-selector.tsx`,
+`lib/expense-store.ts:561-602`
+
+### Behaviour
+
+- The user selects a month (`YYYY-MM`) and a year (`YYYY`). The month drives the Monthly
+  view; the year filters the Dashboard.
+- Month selector: a dropdown of the 12 months plus previous/next arrow buttons. Moving past
+  December rolls to January of the next year and updates the selected year with it.
+- Year selector: a dropdown plus arrows. The available-years list is every year present in
+  the data, **plus the current year always**, sorted descending.
+- Changing the year when the selected month is in a different year snaps the month to
+  `{year}-01`.
+
+### Required changes
+
+- Selected month and year move to **URL search params** (ADR-002). They are navigation
+  state, not persisted domain state.
+- Removing them from the store removes the reason `setCurrentMonth` eagerly materialises
+  data → **P-06**.
+
+### Edge cases
+
+- Year list must include the current year even when there is no data for it, or a new user
+  sees an empty selector.
+- Arrow navigation must cross year boundaries in both directions.
+- A malformed month in the URL (`/months/2026-13`, `/months/banana`) must be rejected at the
+  route boundary and redirect to the current month — not crash a selector.
+
+### Pitfalls
+
+`→ P-06` (month materialisation) · `→ P-13` (date parsing)
+
+---
+
+## F-02 · Income
+
+**Old reference:** `components/expense/income-input.tsx`, `income-list.tsx`,
+`lib/expense-store.ts:663-850`
+
+### Behaviour
+
+- An income has a **description** and an **amount**. Nothing else.
+- Add, edit, and remove income within a month.
+- **Recurring income.** On creation the user may tick "make recurring". If ticked, the
+  income is written to the current month **and the following 24 months**, all sharing a
+  `recurringGroupId`.
+- Editing a recurring income updates **this month and all future months** in the group.
+  Past months keep their old values.
+- Removing a recurring income removes it from **this month onward**. Past months keep it.
+- Editing a non-recurring income into a recurring one removes the original and re-adds it
+  with replication.
+- A recurring item is visually badged as such in the list.
+
+### Required changes
+
+- Do **not** materialise 25 rows per recurring income. Store the **rule** and expand it for
+  the requested month. → **P-04**
+- With a rule-based model, "edit from this month onward" becomes: close the current rule at
+  the previous month and open a new rule from this month. This is exact, cheap, and unbounded
+  — the old app's 24-month horizon silently ends recurrence after two years. → **P-07**
+
+### Edge cases
+
+- Edit-from-month and delete-from-month must not touch history.
+- The old implementation compares month keys with `>=` **string** comparison
+  (`lib/expense-store.ts:759`, `808`, `1181`, `1212`). This is correct only because
+  `YYYY-MM` is lexicographically ordered — keep that property or compare parsed values.
+- Toggling recurrence off on an existing recurring income is **not implemented in the old
+  app**. Decide the behaviour explicitly and specify it; do not leave it undefined.
+
+### Pitfalls
+
+`→ P-04` (fan-out) · `→ P-07` (24-month horizon) · `→ P-14` (ID generation)
+
+---
+
+## F-03 · Expenses — Fixed and Variable
+
+**Old reference:** `components/expense/expense-form.tsx`, `expense-list.tsx`,
+`expense-edit-dialog.tsx`, `lib/expense-store.ts:997-1248`
+
+### Behaviour
+
+- An expense has **description**, **amount**, **category**, **type** (`fixed` | `variable`),
+  and **date**.
+- Fixed and variable expenses are displayed in two separate lists side by side.
+- **Variable** expenses belong to a single month. Plain add / edit / remove.
+- **Fixed** expenses propagate: adding one writes it to the current month and the following
+  24 months under a shared `recurringGroupId`. Editing or deleting applies from the current
+  month forward, exactly like recurring income.
+- A fixed expense may also be non-recurring (created before propagation existed, or edited
+  into a single-month item); the edit dialog offers "make recurring".
+- The form's date is always set to the **first day of the selected month**
+  (`currentMonth + '-01'`) — the day is never chosen by the user, despite `date` being a
+  full `YYYY-MM-DD` field.
+
+### Required changes
+
+- Same rule-based recurrence as F-02. Fixed-expense propagation and income replication are
+  **the same mechanism** and must share one implementation in `domain/recurrence.ts`. The
+  old app implements them twice, differently.
+- Decide whether `date` keeps day precision. It is currently always `-01` for fixed expenses
+  and user-irrelevant for variable ones. Recommended: keep `YYYY-MM-DD` and **let the user
+  pick the day for variable expenses** — the field already exists and the data is more
+  useful. Specify whichever you choose.
+- Every string in the form is hardcoded Portuguese while `forms.expense.*` keys exist unused
+  in both message files. → **P-08**
+- The amount input uses `step="0.01"`, which `CLAUDE.md` explicitly forbids. With integer
+  cents (ADR-005) this becomes a parsing decision, not a stepper decision.
+
+### Edge cases
+
+- `expense-form.tsx:118` calls `.sort()` directly on the array returned from the Zustand
+  selector — an in-place mutation of store state during render. → **P-09**
+- Deleting a category reassigns its expenses to the system category `other`; it must not
+  delete them. See F-05.
+- An expense whose `category` no longer exists must render as `other` rather than blank.
+  The old app has `validateCategory()` for this (`lib/expense-store.ts:1456`) but the
+  Dashboard re-implements the same fallback inline (`dashboard-view.tsx:125-127`).
+
+### Pitfalls
+
+`→ P-04` · `→ P-07` · `→ P-08` (hardcoded strings) · `→ P-09` (selector mutation)
+
+---
+
+## F-04 · Installments (credit-card purchases split over months)
+
+**Old reference:** `components/expense/installments.tsx`,
+`lib/expense-store.ts:1250-1305`, `mapInstallmentsToExpenses` at `:501-515`
+
+### Behaviour
+
+- An installment plan has **name**, **credit card**, **total installments** (2–48),
+  **amount per installment**, and **start month**.
+- Plans are **global**, not per-month. A plan appears in month _M_ when
+  `0 <= monthDiff(startMonth, M) < totalInstallments`, displayed as "_name_ _n_/_total_".
+- Installments are **not** stored as expenses. They are projected into a month at read time
+  and folded into that month's expense total and category breakdown as synthetic expenses.
+- The Monthly view shows this month's occurrences plus their summed amount.
+- Plans can be created and deleted. **There is no edit.**
+
+### Required changes
+
+- `mapInstallmentsToExpenses` defaults the synthetic category to `'parcelamento'`, a
+  Portuguese ID that **no longer exists** after the v1→v2 migration renamed it to
+  `'installment'`. Both call sites use the default. → **P-10** (a live, user-visible bug)
+- The card `Select` has no required-validation, and the post-submit reset assigns
+  `setCard('nubank_pri')` (`installments.tsx:66`) — a hardcoded legacy card ID that no
+  longer exists. A plan can be created with an empty card. → **P-11**
+- The 2–48 bound exists only as an HTML `min`/`max` attribute. Enforce it in the schema.
+- Add edit support, or explicitly decide not to and say so in the UI.
+
+### Edge cases
+
+- Deleting a credit card that has active plans requires reassigning them (see F-06).
+- `getInstallmentsForMonth` relies on `differenceInMonths` over dates built as
+  `new Date(year, month - 1, 1)`. Keep that construction — building from a string
+  (`new Date('2026-07')`) parses as UTC and shifts by a day in negative-offset timezones.
+  → **P-13**
+- A plan starting in a month the user later deletes via "delete year data" survives only if
+  its `startMonth` is outside the deleted year (`lib/expense-store.ts:1684-1687`).
+
+### Pitfalls
+
+`→ P-10` (wrong category ID) · `→ P-11` (phantom card) · `→ P-13` (date parsing)
+
+---
+
+## F-05 · Categories
+
+**Old reference:** `components/expense/categories-view.tsx`, `category-form-dialog.tsx`,
+`icon-selector.tsx`, `color-selector.tsx`, `lib/expense-store.ts:1307-1460`
+
+### Behaviour
+
+- 11 default categories ship with the app: groceries, transportation, health, leisure, food,
+  education, housing, subscriptions, credit-card, installment, and **other**.
+- `other` is the **system category**: it cannot be renamed or deleted (`isSystem: true`).
+- Users create custom categories with a **name**, a **colour** from a fixed 20-colour
+  palette, and an optional **Lucide icon**.
+- Categories are reorderable by drag and drop (`@dnd-kit`); order persists.
+- Deleting a category **reassigns its expenses to `other`** — it never deletes expenses.
+- Category IDs are derived from the name by kebab-casing with accent stripping
+  (`"Alimentação"` → `"alimentacao"`). Duplicate IDs are rejected.
+
+### The label model — read carefully
+
+This trips up every reader. A category's display name comes from **one of two places**:
+
+- **Default categories** have no stored label. Their ID is an **i18n key**: `groceries`
+  resolves through `categories.groceries` and therefore translates with the UI language.
+- **Custom categories** store a `customLabel` and are **never translated** — the user typed
+  it, so it renders verbatim in both languages.
+
+Resolution is always `category.customLabel ?? t('categories.' + category.id)`. Preserve this.
+It is the correct design and is easy to accidentally flatten into a single stored string.
+
+### Required changes
+
+- Store errors are thrown as hardcoded Portuguese strings
+  (`lib/expense-store.ts:1468`, `1504`, `1527`). Throw typed errors; map to messages in the
+  UI. → **P-08**
+- `validateCategory()` and the Dashboard's inline fallback do the same job in two places.
+  One implementation, in `domain/categories.ts`.
+
+### Edge cases
+
+- Two different names can normalise to the same ID (`"Saúde"` and `"Saude"`). The duplicate
+  check catches it, but the error must be understandable.
+- A name that normalises to an empty string (e.g. `"🎉"`) produces `id: ''`. **Unhandled in
+  the old app** — a category with an empty ID is created. Reject it.
+- A custom category whose ID collides with a default one (a user naming something
+  "Groceries") would shadow the i18n key. Guard against it.
+- Reordering must renumber `order` contiguously from 0.
+
+### Pitfalls
+
+`→ P-08` · `→ P-12` (empty-ID normalisation)
+
+---
+
+## F-06 · Credit Cards
+
+**Old reference:** `components/expense/credit-cards-view.tsx`, `credit-card-form-dialog.tsx`,
+`lib/expense-store.ts:1462-1611`
+
+### Behaviour
+
+- A card has **name**, **colour**, and an optional **monthly limit** (`null` = no limit).
+- Full CRUD plus drag-and-drop reordering.
+- Cards start empty — there are no defaults. The Installments form disables its card
+  selector and prompts the user to create a card first when none exist.
+- Three derived figures per card:
+  - **Usage this month** — sum of installment amounts falling in the current month.
+  - **Total commitment** — `amountPerInstallment × totalInstallments` summed across all the
+    card's plans, _for the whole life of each plan_.
+  - **Usage percentage** — `totalCommitment / limit × 100`, or `null` when there is no limit.
+- Deleting a card with active plans **requires** choosing another card to reassign them to;
+  the store throws if one is not supplied.
+
+### Required changes
+
+- The percentage compares a **lifetime** commitment against a **monthly** limit
+  (`lib/expense-store.ts:1602-1611`). A 12×R$100 plan on a R$1,000-limit card reports 120%
+  usage while only consuming R$100/month. This is a definitional bug, not a rounding one.
+  → **P-15**
+- The delete-confirmation copy says _"They will be deleted as well"_
+  (`ui.creditCards.confirmDeleteWarning`) while the code **reassigns** them. The message
+  contradicts the behaviour. → **P-16**
+
+### Edge cases
+
+- Reassignment target must exclude the card being deleted.
+- Deleting a card must not orphan plans under a non-existent card ID.
+- `limit: 0` and `limit: null` are different states — "zero limit" vs "no limit". The form's
+  validation message says the limit must be greater than zero **or empty**; keep both
+  representable and distinct.
+
+### Pitfalls
+
+`→ P-15` (usage maths) · `→ P-16` (copy contradicts behaviour)
+
+---
+
+## F-07 · Savings Entries ("Reserves & Investments")
+
+**Old reference:** `components/expense/savings-entries-section.tsx`,
+`savings-entry-form-dialog.tsx`, `lib/expense-store.ts:855-938`
+
+### Behaviour
+
+- An entry has **amount**, **date**, optional **source** (free text: "Nubank", "Treasury"),
+  optional **note**, optional **linked goal**, and a **confirmed** flag meaning
+  _"I have actually transferred this"_.
+- Entries belong to a month and are listed inside the Income panel of the Monthly view.
+- Unconfirmed entries are a **forecast**; confirmed entries are real. Goals count only
+  confirmed amounts toward progress and show unconfirmed separately (see F-08).
+- The Monthly summary subtracts total reserves from the net balance:
+  `net = income − expenses − reserves`.
+
+### Required changes
+
+- The store has two parallel APIs for the same data: month-scoped
+  (`addSavingsEntry(month, …)`, `updateSavingsEntry`, `removeSavingsEntry`) and
+  global-by-ID (`updateSavingsEntryById`, `removeSavingsEntryById`, which loop over every
+  month to find the entry). Keep **one**. → **P-17**
+- Savings entries have **no cloud persistence whatsoever** in the old app. This is only
+  survivable because Phase 1 is local-only — but it must be designed into the sync model
+  from the start when cloud arrives. → **P-01**
+
+### Edge cases
+
+- Deleting a linked goal must clear `goalId` on its entries without deleting them
+  (`lib/expense-store.ts:954-968` does this correctly — preserve it).
+- The net-balance formula counts reserves as an outflow. This is intentional: money moved to
+  savings is not spendable. Keep it and keep the formula visible in the UI
+  (`ui.summary.balanceFormula`).
+
+### Pitfalls
+
+`→ P-01` (no persistence path) · `→ P-17` (duplicate API)
+
+---
+
+## F-08 · Goals
+
+**Old reference:** `components/expense/goals-view.tsx`, `goal-card.tsx`,
+`goal-form-dialog.tsx`, `goal-detail-sheet.tsx`, `goal-progress-bar.tsx`,
+`lib/goal-utils.ts`, `lib/expense-store.ts:940-995`
+
+### Behaviour
+
+- A goal has **name**, **icon**, **colour**, **target amount**, optional **deadline**
+  (`YYYY-MM`), and a **status** (`active` | `completed`).
+- Savings entries link to goals. Progress counts **confirmed entries only**; unconfirmed
+  amounts show as a separate "forecast" figure.
+- Derived values (`lib/goal-utils.ts`):
+  - `progressPercent` = `min(100, confirmed / target × 100)`
+  - `monthlyNeeded` = `remaining / monthsUntilDeadline`, `null` without a deadline or when
+    the deadline has passed
+  - `status` ∈ `on-track` | `behind` | `ahead` | `overdue` | `completed`
+- Goals can be completed manually and reactivated. Completing stamps `completedAt`;
+  reactivating strips it.
+- Completed goals are listed in a separate section.
+- Deleting a goal unlinks its savings entries rather than deleting them.
+
+### Required changes
+
+- `lib/goal-utils.ts` is otherwise clean and pure — it is the **model** for what
+  `domain/` should look like. Port it near-verbatim into `domain/goals.ts`, converted to
+  integer cents.
+- The `ahead` status does not mean what its name says. `getGoalStatus` returns `ahead` only
+  when `confirmed >= targetAmount` — i.e. "target already reached but not marked complete".
+  A goal genuinely ahead of the schedule implied by its deadline (60% saved with 80% of the
+  time left) returns `on-track`. Either rename it to `reached`, or implement it as an
+  actual schedule comparison. → **P-18**
+
+### Edge cases
+
+- `targetAmount <= 0` returns 0% rather than dividing by zero — keep the guard.
+- A deadline in the current month gives `monthsLeft === 0` → `monthlyNeeded` is `null`, and
+  status is `overdue` once `now >= deadlineDate`. Both branches need tests with
+  `vi.setSystemTime()`.
+- `getGoalStatus` derives "months elapsed" from `goal.createdAt`; a goal created _after_ its
+  deadline yields `totalMonths <= 0` and short-circuits to `on-track`. Preserve or fix
+  deliberately.
+- The deadline `<Input type="month">` must not accept past months (per `CLAUDE.md`).
+
+### Pitfalls
+
+`→ P-01` · `→ P-18` (unreachable status)
+
+---
+
+## F-09 · Notes
+
+**Old reference:** `components/expense/notes-section.tsx`, `note-form-dialog.tsx`,
+`lib/expense-store.ts:1613-1669`
+
+### Behaviour
+
+- A note has **text**, optional **value**, optional **direction** (`payable` = I owe /
+  `receivable` = owed to me), an **event date**, a **persistent** flag, a **done** flag, a
+  creation timestamp, and the **month it originated in**.
+- Notes are informational: they never enter income, expense, or balance totals.
+- **Persistence rule** — a note appears in month _M_ when:
+  `createdMonth === M` **OR** (`persistent` AND NOT `done` AND `createdMonth < M`)
+  So a persistent note follows the user forward through months until ticked done.
+- Notes carried from a past month are pinned to the top and badged "recurring".
+- `done` is toggled inline by a checkbox; done notes render struck through.
+- Notes with a value and not done are aggregated on the Dashboard into "payable" and
+  "receivable" totals.
+
+### Required changes
+
+- The filtering rule is implemented **twice**: in `getNotesForMonth`
+  (`lib/expense-store.ts:1664-1669`) and again in the component
+  (`notes-section.tsx:45-47`), which re-partitions what the store already filtered. One
+  implementation, in `domain/`.
+- Dates render raw: `{note.date}` prints `2026-07-14` verbatim, `note.createdMonth` prints
+  `2026-07`, and `new Date(note.createdAt).toLocaleDateString()` uses the **system** locale
+  rather than the app's. → **P-19**
+
+### Edge cases
+
+- `note.value !== undefined` gates the direction icon, so a note with `value: 0` shows a
+  direction indicator with a zero amount. Decide whether 0 is a valid value.
+- A persistent note that is done in a later month still appears in its **origin** month —
+  correct, since the first clause matches unconditionally.
+- The Dashboard aggregate filters `n.value && n.value > 0`, which is a stricter test than
+  the one the notes list uses. Align them.
+
+### Pitfalls
+
+`→ P-19` (raw/system-locale dates)
+
+---
+
+## F-10 · Dashboard
+
+**Old reference:** `components/expense/dashboard-view.tsx` (717 lines),
+`category-breakdown.tsx`
+
+### Behaviour
+
+Everything is scoped to the **selected year**.
+
+- **Four stat tiles:** average monthly expenses; month-over-month expense change (%); total
+  saved this year; savings rate (`savings / income` of the latest month).
+- **Pending financial notes** panel — payable and receivable columns with totals, shown only
+  when there is at least one pending valued note.
+- **Charts** (recharts):
+  - Income vs Expenses — area chart, gradient fills, by month
+  - Fixed vs Variable — grouped bar chart, by month
+  - Spending distribution — donut chart of the **top 6** categories by average
+  - Savings trend — line chart, by month
+- **Category averages grid** — every category with data, showing monthly average, sorted
+  descending, with the category's icon and colour.
+- Installments are included in expense totals and in the category breakdown.
+- Empty states: "no data for {year}" when the year has no months.
+
+### Required changes
+
+This screen needs the most work of any in the app.
+
+- **Every visible string is hardcoded Portuguese**, including headings, chart series names,
+  and axis content — while `ui.dashboard.*` keys exist, translated, in both message files
+  and are entirely unused. → **P-08**
+- Month labels come from `date.toLocaleDateString('pt-BR', { month: 'short' })`
+  (`dashboard-view.tsx:78`) — hardcoded locale. Use the app locale, or the existing
+  `monthsShort.*` keys.
+- The `isHydrated` gate (`:51-55`) hides the entire dashboard behind a loading card on first
+  render. It exists solely to avoid SSR hydration mismatch and **must not be ported** — the
+  SPA has no server render to mismatch against (ADR-001).
+- 717 lines in one component. Split: one component per chart, one for the tile row, one for
+  the notes panel. Move every `useMemo` aggregation into `domain/` as pure functions with
+  their own tests — these are the numbers the user makes decisions on and they are currently
+  untested.
+- Lazy-load the route: recharts is heavy and only this screen needs it.
+
+### Edge cases
+
+- Insights require **at least two months** of data or the tile row is hidden entirely.
+- `savingsRate` divides by income and guards `income > 0`.
+- The pie shows the top 6 categories with no "other" bucket, so percentages do not total
+  100%. Either add the bucket or label the chart as a top-N view.
+- Category averages divide by the number of months **with non-zero spend** in that category,
+  not by 12 — an "average" over a different denominator per row. Document this in the UI or
+  change it; today it is silently inconsistent.
+
+### Pitfalls
+
+`→ P-08` · `→ P-10` · `→ P-20` (untested aggregations)
+
+---
+
+## F-11 · Monthly View
+
+**Old reference:** `components/expense/monthly-view.tsx`, `summary-cards.tsx`
+
+### Behaviour
+
+The main working screen. Composition:
+
+- Header: title plus the month selector.
+- **Summary cards:** total income, total expenses (with % change vs previous month), total
+  reserves, and a full-width **net balance** card (`income − expenses − reserves`), coloured
+  by sign.
+- Left column: Income + Savings panel, Installments panel, Category breakdown.
+- Right column: Fixed expenses and Variable expenses lists, side by side.
+- Full width below: Notes.
+
+### Required changes
+
+- **The month-over-month comparison compares unlike quantities.** `totalExpenses` for the
+  current month _includes_ installments (`monthly-view.tsx:115-118`), while
+  `prevMonthTotalExpenses` _excludes_ them (`:102-105`). The percentage shown to the user is
+  wrong whenever installments exist in either month. → **P-21**
+- `summary-cards.tsx:34` guards with `previousMonthExpenses ?` (truthy), so a previous month
+  with exactly `0` expenses is treated as "no previous data" instead of a valid baseline.
+- `monthly-view.tsx:62` builds a fallback recurring-group ID with
+  `Math.random().toString(36)` while the store uses `crypto.randomUUID()`. Two ID schemes for
+  one concept. → **P-14**
+
+### Edge cases
+
+- The view returns `null` while the month is uninitialised (`:49-51`), producing a blank
+  frame on first paint. With derived-on-read month data (**P-06**) this guard disappears.
+- Previous-month lookup constructs a `Date` and decrements the month — fine, but it belongs
+  in `domain/month.ts` alongside every other month calculation.
+
+### Pitfalls
+
+`→ P-06` · `→ P-14` · `→ P-21` (inconsistent comparison)
+
+---
+
+## F-12 · Settings
+
+**Old reference:** `components/expense/settings-view.tsx`, `app/settings/page.tsx`
+
+### Behaviour
+
+- **Language** — switch between `pt` and `en`.
+- **Data management:**
+  - **Delete a year** — removes all months, installments starting that year, and notes
+    created that year. Confirmed via dialog listing what will be removed.
+  - **Delete everything** — double-confirmed by typing a phrase, listing what will be lost.
+- **Cloud section** — deferred to the cloud phase; absent in Phase 1.
+
+### Required changes
+
+- **The English confirmation is impossible to satisfy.** The gate is
+  `confirmationText !== 'DELETAR TUDO'` (`settings-view.tsx:102`, repeated at `:315`) while
+  the English instruction says to type `DELETE ALL`. An English-language user can never
+  delete their data. → **P-05**
+- **The dialog lies about what is deleted.** It lists "All custom categories" and "All credit
+  cards", but `deleteAllData()` (`lib/expense-store.ts:1706-1715`) resets only `monthlyData`,
+  `installments`, `notes`, and `goals`. Categories and cards survive. → **P-22**
+- Language changes call `window.location.reload()` (`:57`). With client-side i18n this is a
+  state update.
+- Locale is written to **both** a cookie and `localStorage` (`:54-55`) — two sources of truth.
+  Keep one.
+
+### Must add
+
+**Export and import.** `ui.settings.exportData` / `importData` / `exportSuccess` /
+`importSuccess` keys already exist, translated, in both message files — the feature was
+specified and never built. For a local-first app this is not optional: it is the user's only
+backup, their migration path off the old app, and the thing that makes "your data is yours"
+true. Ship JSON export/import in Phase 1.
+
+### Edge cases
+
+- Deleting the year currently selected must reset the selection to the present month.
+- Delete-all must reset **everything** including categories and cards, or the copy must say
+  what it actually does. Prefer the former.
+- Both destructive actions must be undoable-by-export: prompt an export first, or at minimum
+  make export prominent on the same screen.
+
+### Pitfalls
+
+`→ P-05` (untranslated gate) · `→ P-22` (dialog contradicts behaviour)
+
+---
+
+## F-13 · Theme
+
+**Old reference:** `components/theme-provider.tsx`, `theme-toggle.tsx`
+
+### Behaviour
+
+Light / dark / system, persisted, with no flash of wrong theme on load.
+
+### Required changes
+
+- `next-themes` goes with Next.js. Replace with ~30 lines: read `prefers-color-scheme`,
+  allow an explicit override in `localStorage`, apply a class to `<html>`, and set it from a
+  blocking inline script in `index.html` to prevent the flash.
+- The `mounted` gate in `theme-toggle.tsx:11-17` is an SSR workaround and must not be ported.
+
+---
+
+## F-14 · Internationalisation
+
+**Old reference:** `messages/en.json`, `messages/pt.json`, `i18n/`, `proxy.ts`,
+`lib/locale-cookie.ts`
+
+### Behaviour
+
+- Two locales: `en` and `pt`. Default `pt`. No URL prefix.
+- 502 keys, at near-perfect parity — `ui.auth.connectAccount` and `ui.auth.loginDescription`
+  exist only in `pt`.
+- Detection order: explicit user choice → `Accept-Language` → default.
+
+### Required changes
+
+- `next-intl` → `use-intl`. **The message files carry over unchanged.**
+- Locale detection moves to the client: `localStorage` → `navigator.language` → default.
+  `proxy.ts` is deleted.
+- Delete keys that are dead by design: `ui.dashboard.totalInvestments` and
+  `ui.dashboard.investmentRate` are remnants of the investments feature removed by schema
+  migration v2→v3.
+- Add the two missing `en` keys.
+- Everything in ADR-006 applies: lint rule against literals, CI parity check, locale-bound
+  formatters, typed domain errors.
+
+### Edge cases
+
+- Currency and language are **independent**. A user may want English UI with BRL amounts.
+  The old `SupportedCurrency` type (`BRL | USD | EUR`) anticipates this but no UI ever sets
+  it. Either ship a currency setting or hardcode BRL honestly — do not keep a parameter that
+  pretends to be configurable.
+
+---
+
+## F-15 · Cloud Sync, Workspaces, Auth — **DEFERRED**
+
+**Old reference:** `amplify/`, `lib/workspace-client.ts`, `lib/write-queue.ts`,
+`lib/sync-store.ts`, `lib/lambda-client.ts`, `lib/adapters/`, `components/workspace/`,
+`app/auth/`, `app/onboarding/`, `app/invite/`
+
+**Not in Phase 1.** Per ADR-003 this is designed against a finished local app.
+
+Recorded here so the behaviour is not lost:
+
+- Google OAuth via Cognito; each workspace maps to a Cognito Group `workspace-{uuid}`.
+- Maximum 2 members per workspace, enforced in the `acceptInvite` Lambda.
+- One-time, expiring invite links.
+- Smart sync: compare `Workspace.lastActivityAt` against `lastSyncedAt` on mount and focus;
+  re-fetch only when the cloud is newer.
+- A localStorage-backed write queue with 3 retries and a dead-letter bucket.
+- Conflict resolution is whole-dataset choose-one — "keep local" or "keep cloud", with the
+  loser permanently replaced (`ui.sync.conflict*`).
+
+**Known gaps to design away rather than reproduce** — see `04`:
+`P-01` (goals and savings never sync at all), `P-02` (deletes never sync),
+`P-03` (queue is not concurrency-safe), `P-04` (per-record mutation fan-out).

--- a/docs/migration/03-domain-model.md
+++ b/docs/migration/03-domain-model.md
@@ -1,0 +1,411 @@
+# 03 — Domain Model
+
+The canonical data model for the new app, and how old data maps onto it.
+
+Read this before writing any type, store, or persistence code.
+
+---
+
+## Principles
+
+1. **The domain model owes nothing to any backend.** No `workspaceGroup`, no
+   `monthlyDataId`, no `cloudId`. Sync concerns belong to the sync layer when it exists
+   (ADR-003).
+2. **Money is integer cents** (ADR-005). Never a float, never a formatted string.
+3. **Make illegal states unrepresentable.** Branded types for `MonthKey`, `IsoDate`, and
+   `Cents` cost nothing at runtime and eliminate a whole class of bug the old app has
+   (`getMonthDiff` silently returns `NaN` for a malformed key).
+4. **Store facts, derive views.** Recurrence is a rule, not 25 copies of a row. Installment
+   occurrences are computed, not stored.
+
+---
+
+## Primitive types
+
+```ts
+/** Integer cents. 1 BRL = 100. Never fractional. */
+export type Cents = number & { readonly __brand: 'Cents' }
+
+/** Calendar month, always `YYYY-MM`. Lexicographic order == chronological order. */
+export type MonthKey = string & { readonly __brand: 'MonthKey' }
+
+/** Calendar date, always `YYYY-MM-DD`. No time, no timezone. */
+export type IsoDate = string & { readonly __brand: 'IsoDate' }
+
+/** Instant, ISO 8601 with timezone. Used only for audit fields. */
+export type Timestamp = string & { readonly __brand: 'Timestamp' }
+
+export type Uuid = string & { readonly __brand: 'Uuid' }
+```
+
+Each gets a parser and a guard in `domain/`. Parsing happens **at the boundary** — form
+input, URL params, imported JSON — never in the middle of a calculation.
+
+> **Why `MonthKey` is branded.** The old `getMonthDiff` (`lib/expense-store.ts:484-490`)
+> splits on `-` and calls `Number()`. Given `"banana"` it produces `NaN`, and
+> `differenceInMonths` then returns `NaN`, and the installment silently never appears in any
+> month. No error, no log. A branded type with a parser at the boundary makes that
+> unreachable.
+
+---
+
+## Entities
+
+### Category
+
+```ts
+export type Category = {
+  id: CategoryId // kebab-case; for defaults this IS the i18n key
+  customLabel?: string // present only for user-created categories
+  color: HexColor
+  icon: string | null // Lucide icon name
+  isSystem: boolean // true only for 'other'
+  order: number // contiguous from 0
+}
+```
+
+**The dual-label rule (F-05) is load-bearing.** Default categories have no `customLabel`;
+their `id` resolves through `t('categories.' + id)` and therefore translates. Custom
+categories carry a `customLabel` and are never translated. Resolution is always:
+
+```ts
+const label = category.customLabel ?? t(`categories.${category.id}`)
+```
+
+Do not flatten this into one stored string — it would freeze default categories into
+whatever language they were created in.
+
+**System category:** exactly one, `id: 'other'`, `isSystem: true`. It cannot be renamed or
+deleted, and it is the reassignment target when any other category is deleted.
+
+**Defaults** (11): `groceries`, `transportation`, `health`, `leisure`, `food`, `education`,
+`housing`, `subscriptions`, `credit-card`, `installment`, `other`.
+
+> Note that `installment` is a _category_ and installments are also a _feature_. The
+> category exists so projected installment occurrences land somewhere in the breakdown.
+> This is the ID that pitfall **P-10** gets wrong.
+
+### CreditCard
+
+```ts
+export type CreditCard = {
+  id: CardId
+  name: string
+  color: HexColor
+  limit: Cents | null // null = no limit; 0 is a distinct, valid state
+  order: number
+}
+```
+
+### Income
+
+```ts
+export type Income = {
+  id: Uuid
+  month: MonthKey
+  description: string
+  amount: Cents
+  recurrenceId?: Uuid // set when this row came from a recurrence rule
+}
+```
+
+### Expense
+
+```ts
+export type Expense = {
+  id: Uuid
+  month: MonthKey
+  description: string
+  amount: Cents
+  categoryId: CategoryId
+  kind: 'fixed' | 'variable'
+  date: IsoDate
+  recurrenceId?: Uuid
+}
+```
+
+**Renamed from the old model:** `type` → `kind` (`type` is a TypeScript keyword and reads
+badly in generics), `category` → `categoryId` (it is a reference, and the old name invited
+the bug where a whole category object was expected).
+
+**Dropped:** `installmentId`. In the old model this only ever appeared on _synthetic_
+expenses fabricated at read time by `mapInstallmentsToExpenses` — it was never persisted on
+a real expense. Keeping it on the stored type advertised a relationship that does not exist.
+Projected occurrences carry their own type (below).
+
+### Recurrence — the central modelling change
+
+The old app materialises recurrence: creating one recurring income writes **25 rows**
+(current month + 24). Consequences: a fixed 2-year horizon that silently ends
+(**P-07**), 25 records to update on every edit, and in cloud mode 25 queued mutations per
+action (**P-04**).
+
+Store the rule instead:
+
+```ts
+export type Recurrence = {
+  id: Uuid
+  kind: 'income' | 'expense'
+  startMonth: MonthKey
+  endMonth: MonthKey | null // null = open-ended
+  template: {
+    description: string
+    amount: Cents
+    categoryId?: CategoryId // expenses only
+  }
+}
+```
+
+A month's rows are `storedRows(month) ++ expandRecurrences(rules, month)`.
+
+**Edits become rule surgery, and the old semantics fall out for free:**
+
+| User action                           | Operation                                                                                   |
+| ------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Edit from month _M_ onward            | Set `endMonth = M-1` on the existing rule; create a new rule from _M_ with the new template |
+| Delete from month _M_ onward          | Set `endMonth = M-1`; if `M <= startMonth`, delete the rule                                 |
+| Make an existing single row recurring | Delete the row; create a rule starting at its month                                         |
+| Override one month only               | Store an explicit row for that month plus a `skip` on the rule (see below)                  |
+
+**Exceptions.** Users will eventually edit a single month of a recurring series. Model it
+now rather than retrofitting:
+
+```ts
+exceptions: Record<MonthKey, { skip: true } | { override: Partial<Template> }>
+```
+
+Do not build the exception _UI_ in Phase 1, but reserve the field so it does not become a
+schema migration later.
+
+### Installment
+
+```ts
+export type Installment = {
+  id: Uuid
+  name: string
+  cardId: CardId // required — never empty (P-11)
+  totalInstallments: number // integer, 2..48
+  amountPerInstallment: Cents
+  startMonth: MonthKey
+}
+```
+
+Occurrences are **derived**, never stored:
+
+```ts
+export type InstallmentOccurrence = {
+  installment: Installment
+  number: number // 1-based
+  month: MonthKey
+}
+
+// present in month M when 0 <= monthDiff(startMonth, M) < totalInstallments
+```
+
+### SavingsEntry
+
+```ts
+export type SavingsEntry = {
+  id: Uuid
+  month: MonthKey
+  amount: Cents
+  date: IsoDate
+  source?: string // free text
+  note?: string
+  goalId?: Uuid
+  confirmed: boolean // false = forecast, true = actually transferred
+}
+```
+
+`confirmed` is the axis everything else keys off: goal progress counts only confirmed
+entries; unconfirmed ones surface separately as a forecast.
+
+### Goal
+
+```ts
+export type Goal = {
+  id: Uuid
+  name: string
+  icon: string
+  color: HexColor
+  targetAmount: Cents
+  deadline?: MonthKey
+  status: 'active' | 'completed'
+  completedAt?: Timestamp
+  createdAt: Timestamp
+}
+```
+
+### Note
+
+```ts
+export type Note = {
+  id: Uuid
+  text: string
+  value?: Cents
+  valueDirection?: 'payable' | 'receivable'
+  date: IsoDate // the event date
+  persistent: boolean
+  done: boolean
+  createdAt: Timestamp
+  createdMonth: MonthKey // origin month
+}
+```
+
+**Visibility rule** — belongs in `domain/notes.ts`, implemented once:
+
+```
+visibleIn(note, M) =
+  note.createdMonth === M
+  || (note.persistent && !note.done && note.createdMonth < M)
+```
+
+> The old model calls this field `noteCreatedAt` in the cloud schema purely to dodge a
+> collision with Amplify's own `createdAt` (`amplify/data/resource.ts:190`). With no cloud
+> in Phase 1 it is plain `createdAt`.
+
+---
+
+## Store shape
+
+```ts
+// stores/ledger-store.ts
+{
+  incomes:       Record<MonthKey, Income[]>
+  expenses:      Record<MonthKey, Expense[]>
+  savingsEntries:Record<MonthKey, SavingsEntry[]>
+  recurrences:   Recurrence[]
+}
+
+// stores/catalog-store.ts
+{
+  categories:  Category[]
+  creditCards: CreditCard[]
+}
+
+// stores/planning-store.ts
+{
+  installments: Installment[]
+  goals:        Goal[]
+  notes:        Note[]
+}
+```
+
+**Deliberately absent:**
+
+- `currentMonth` / `currentYear` — navigation state, now URL params (ADR-002).
+- `isLoading`, `workspaceId` — cloud concerns (ADR-003).
+- The `MonthlyData` wrapper. The old shape nests four arrays under a `month` key _and_
+  stores `month` inside the object, so the key and the field can disagree. Flat records keyed
+  by month remove that possibility.
+- Eagerly created empty months. `getMonthData` returns `incomes: [], expenses: []` for any
+  month with no data; nothing is written until the user enters something (**P-06**).
+
+---
+
+## Invariants
+
+Enforce these in `domain/`, and assert them in tests:
+
+1. Every `MonthKey` matches `^\d{4}-(0[1-9]|1[0-2])$`.
+2. Every `amount` is a non-negative integer. Money is never fractional, never negative.
+   _(Sign is carried by the entity type — an expense is an outflow by definition.)_
+3. Every `Expense.categoryId` resolves to an existing category, or is rendered as `other`.
+   Deleting a category rewrites its expenses to `other`; it never deletes them.
+4. Exactly one category has `isSystem: true`, and its id is `other`.
+5. `category.order` and `creditCard.order` are contiguous from 0 after any mutation.
+6. Every `Installment.cardId` resolves to an existing card. Deleting a card requires
+   reassignment.
+7. `2 <= totalInstallments <= 48`, integer.
+8. A `Recurrence` with `endMonth !== null` satisfies `endMonth >= startMonth`.
+9. `SavingsEntry.goalId`, when present, resolves to an existing goal. Deleting a goal clears
+   the field; it never deletes the entry.
+10. `Goal.completedAt` is present **iff** `status === 'completed'`.
+
+---
+
+## Persistence
+
+**IndexedDB**, via the Zustand `persist` middleware with a custom async storage
+(ADR-003). One record per store, versioned:
+
+```ts
+{ version: 1, data: { /* store state */ } }
+```
+
+The old app stores everything as one localStorage JSON blob under `expense-store`, parsed
+and re-serialised on every mutation, capped near 5 MB and synchronous.
+
+### Schema migrations
+
+Port the _mechanism_ from `lib/migrations.ts` — it is sound: a numbered registry, sequential
+application, a pre-migration backup, and cleanup keeping the last 3 backups.
+
+Fix two things:
+
+1. **Migrations must be pure.** The old `migrateV1ToV2` mutates its input in place and
+   returns the same reference, so a failure halfway through leaves partially migrated data
+   in memory. Take input, return new output.
+2. **Migrations must be tested.** `lib/migrations.ts` is in the coverage `exclude` list
+   (`vitest.config.ts`) — the code that rewrites users' financial data is the least tested
+   code in the repo. Every migration needs a fixture-based round-trip test.
+
+The new app starts at `version: 1`. The old app's v1→v2→v3 history does not carry over; it
+is collapsed into the import path below.
+
+---
+
+## Importing data from the old app
+
+Users have live data in the old app. Import is a **Phase 1 deliverable** (F-12), not a
+nicety — it is the migration path for real people.
+
+Source: the old localStorage key `expense-store`, at schema version 3.
+
+| Old                                       | New                 | Transform                                                       |
+| ----------------------------------------- | ------------------- | --------------------------------------------------------------- |
+| `state.monthlyData[M].incomes[]`          | `incomes[M]`        | `amount × 100`, round once; `recurringGroupId` → `recurrenceId` |
+| `state.monthlyData[M].fixedExpenses[]`    | `expenses[M]`       | `kind: 'fixed'`; `category` → `categoryId`; `amount × 100`      |
+| `state.monthlyData[M].variableExpenses[]` | `expenses[M]`       | `kind: 'variable'`; same                                        |
+| `state.monthlyData[M].savingsEntries[]`   | `savingsEntries[M]` | `amount × 100`                                                  |
+| `state.installments[]`                    | `installments[]`    | `card` → `cardId`; `amountPerInstallment × 100`                 |
+| `state.categories[]`                      | `categories[]`      | direct                                                          |
+| `state.creditCards[]`                     | `creditCards[]`     | `limit × 100` when not null                                     |
+| `state.goals[]`                           | `goals[]`           | `targetAmount × 100`                                            |
+| `state.notes[]`                           | `notes[]`           | `value × 100` when present                                      |
+| `state.currentMonth`, `currentYear`       | _dropped_           | now URL state                                                   |
+
+**Recurrence reconstruction.** Old data has materialised rows sharing a
+`recurringGroupId`. The importer must collapse each group into one `Recurrence`:
+
+```
+for each distinct recurringGroupId:
+  rows        = all rows with that id, sorted by month
+  startMonth  = first row's month
+  endMonth    = last row's month
+  template    = first row's { description, amount, categoryId }
+
+  if any row's description/amount differs from the template:
+      emit those months as explicit exception overrides
+  if the months are not contiguous:
+      emit the gaps as skip exceptions
+```
+
+The old app's edit semantics ("update from this month onward") mean a long-lived series can
+legitimately hold several different values across its months. **Do not assume uniformity** —
+verify per row and emit exceptions. A test fixture with a mid-series value change is
+mandatory.
+
+**Import must be non-destructive:** validate the whole payload, build the new state in
+memory, and commit only if every invariant above holds. On failure, report which record
+failed and change nothing.
+
+### Cents conversion
+
+Multiply by 100 and round **once**, at import:
+
+```ts
+const toCents = (v: number): Cents => Math.round(v * 100) as Cents
+```
+
+Old data holds float artefacts (`1234.5600000000001`). Round at the boundary, never again.

--- a/docs/migration/04-pitfalls.md
+++ b/docs/migration/04-pitfalls.md
@@ -1,0 +1,726 @@
+# 04 — Pitfalls
+
+Defects and traps found in the current Tempest codebase, each with the evidence that proves
+it and the behaviour required in the new app.
+
+**These are not suggestions.** Before a feature is marked done, its linked pitfalls must be
+verified as _not reproduced_ — ideally by a test that would fail if they were.
+
+Ordered by severity. 🔴 = wrong numbers or lost data reach the user. 🟠 = a user is blocked
+or misled. 🟡 = structural, no direct user impact today.
+
+| ID            | Severity | One line                                                                                       |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| [P-13](#p-13) | 🔴       | Date-only strings parse as UTC — dashboard months and previous-month comparison are off by one |
+| [P-21](#p-21) | 🔴       | Month-over-month expense change compares unlike quantities                                     |
+| [P-10](#p-10) | 🔴       | Installments are filed under a category ID that no longer exists                               |
+| [P-05](#p-05) | 🟠       | English users cannot delete their data                                                         |
+| [P-22](#p-22) | 🟠       | Delete-all dialog promises more than the code deletes                                          |
+| [P-01](#p-01) | 🔴       | Goals and savings entries have no persistence path beyond the browser                          |
+| [P-02](#p-02) | 🔴       | Bulk deletions never propagate to the cloud                                                    |
+| [P-03](#p-03) | 🔴       | The write queue loses mutations under concurrency                                              |
+| [P-11](#p-11) | 🟠       | Installments can be created against a card that does not exist                                 |
+| [P-15](#p-15) | 🟠       | Card usage compares a lifetime total against a monthly limit                                   |
+| [P-16](#p-16) | 🟠       | Card delete dialog contradicts the code                                                        |
+| [P-08](#p-08) | 🟠       | An entire screen is hardcoded Portuguese; 36 amounts ignore locale                             |
+| [P-09](#p-09) | 🟠       | A render-time `.sort()` mutates store state                                                    |
+| [P-04](#p-04) | 🟡       | One user action fans out into 25 records / 26 queued mutations                                 |
+| [P-07](#p-07) | 🟡       | Recurrence silently stops after 24 months                                                      |
+| [P-06](#p-06) | 🟡       | Navigating a year writes 12 empty months to storage                                            |
+| [P-12](#p-12) | 🟡       | Category names can normalise to an empty ID                                                    |
+| [P-14](#p-14) | 🟡       | Two different ID generators for one concept                                                    |
+| [P-17](#p-17) | 🟡       | Two parallel APIs for savings entries                                                          |
+| [P-18](#p-18) | 🟡       | Goal status `ahead` does not mean ahead                                                        |
+| [P-19](#p-19) | 🟡       | Note dates render raw or in the system locale                                                  |
+| [P-20](#p-20) | 🟠       | The numbers users make decisions on are untested                                               |
+| [P-23](#p-23) | 🟠       | The riskiest logic has its E2E tests skipped                                                   |
+| [P-24](#p-24) | 🟠       | Coverage excludes the code most likely to be wrong                                             |
+
+---
+
+<a id="p-13"></a>
+
+## P-13 🔴 · Date-only strings parse as UTC
+
+**Evidence.** `components/expense/dashboard-view.tsx:77-78`:
+
+```ts
+const date = new Date(month.month + '-01')
+const monthLabel = date.toLocaleDateString('pt-BR', { month: 'short' })
+```
+
+Per ECMA-262, a **date-only** ISO string is interpreted as **UTC**, while a date-time string
+without an offset is interpreted as local. `toLocaleDateString` then renders in local time.
+In any negative-offset timezone the rendered month is the **previous** one.
+
+Reproduced in `America/Sao_Paulo` — the app's default market, default locale `pt`:
+
+```
+dashboard month label for 2026-07 => jun.
+previous month of 2026-07        => 2026-05   (expected 2026-06)
+local-constructor date           => jul.
+```
+
+Two distinct user-visible failures:
+
+1. **Every month label on every dashboard chart is wrong** — the X axis of the income/expense
+   area chart, the fixed-vs-variable bars, and the savings line are all shifted one month.
+2. **`components/expense/monthly-view.tsx:98-100`** builds the previous-month key the same
+   way, then calls the _local_ getters `getFullYear()`/`getMonth()`. For July it produces
+   `2026-05`. The "vs previous month" figure on the Monthly view compares against **two
+   months ago**.
+
+The same pattern recurs at `dashboard-view.tsx:387` and `:424` for note dates.
+
+The store's own helpers are **correct** — `getMonthDiff` and `getMonthFromOffset`
+(`lib/expense-store.ts:484-498`) use `new Date(year, month - 1, 1)`, the local constructor.
+The bug is confined to components that build dates from strings.
+
+**Required.** No component constructs a `Date` from a string. Ever. All month arithmetic goes
+through `domain/month.ts`, which parses to numeric parts and uses the local constructor:
+
+```ts
+export function monthToDate(m: MonthKey): Date {
+  const [y, mo] = m.split('-').map(Number)
+  return new Date(y, mo - 1, 1)
+}
+```
+
+**Test that would have caught it.** Run the suite under a fixed non-UTC timezone —
+`TZ='America/Sao_Paulo'` in the Vitest config — and assert that the label for `2026-07` is
+July and that `previousMonth('2026-07') === '2026-06'`. Add `TZ` to CI so this can never
+regress silently.
+
+---
+
+<a id="p-21"></a>
+
+## P-21 🔴 · Month-over-month change compares unlike quantities
+
+**Evidence.** `components/expense/monthly-view.tsx`:
+
+```ts
+// :102-105 — previous month EXCLUDES installments
+const prevMonthTotalExpenses = prevMonthData
+  ? prevMonthData.fixedExpenses.reduce(...) + prevMonthData.variableExpenses.reduce(...)
+  : undefined
+
+// :115-118 — current month INCLUDES installments
+const totalExpenses = fixed + variable + installmentsTotal
+```
+
+The percentage handed to `SummaryCards` therefore divides an installment-inclusive number by
+an installment-exclusive one. Any user with an active installment plan sees an inflated
+month-over-month increase. Combined with **P-13**, the baseline is also the wrong month.
+
+**Required.** One function, `domain/totals.ts#monthExpenseTotal(month)`, used for every
+month. Comparisons call it twice; they never inline a second formula.
+
+**Test.** A month with installments compared against a previous month with the same
+installments must report 0% change.
+
+---
+
+<a id="p-10"></a>
+
+## P-10 🔴 · Installments filed under a non-existent category
+
+**Evidence.** `lib/expense-store.ts:501-505`:
+
+```ts
+export const mapInstallmentsToExpenses = (
+  installments: ...,
+  month: string,
+  categoryId: string = 'parcelamento'   // ← Portuguese ID
+): Expense[] => ...
+```
+
+Both call sites use the default — `dashboard-view.tsx:114` and `monthly-view.tsx:121`.
+
+But `'parcelamento'` was renamed to `'installment'` by the v1→v2 migration
+(`lib/migrations.ts:51`), and `DEFAULT_CATEGORIES` defines `id: 'installment'`
+(`lib/expense-store.ts:191`). No category with the ID `parcelamento` exists in any
+post-migration install.
+
+**Consequence.** Every projected installment falls through the category fallbacks and is
+counted as **`other`** — in the dashboard pie chart, in the category-averages grid, and in
+the Monthly view's category breakdown. The dedicated `installment` category, which ships with
+its own icon and colour, is permanently empty. Users' category analysis is silently wrong.
+
+**Required.** No magic string defaults for IDs. Reference the constant
+(`SYSTEM_CATEGORY_ID`-style) and make the parameter required, so a rename cannot leave a
+stale literal behind.
+
+**Test.** Assert that a month with an installment produces a breakdown entry under
+`installment`, not `other`.
+
+---
+
+<a id="p-05"></a>
+
+## P-05 🟠 · English users cannot delete their data
+
+**Evidence.** `components/expense/settings-view.tsx:102` and `:315`:
+
+```ts
+if (confirmationText !== 'DELETAR TUDO') return
+...
+disabled={confirmationText !== 'DELETAR TUDO'}
+```
+
+The instruction shown above the input comes from i18n. In `en.json`:
+
+```json
+"typeDeleteAll": "Type DELETE ALL",
+"typeDeleteAllPlaceholder": "Type DELETE ALL"
+```
+
+An English user follows the instruction exactly, types `DELETE ALL`, and the button stays
+disabled with no explanation. The destructive action is unreachable in one of the two
+shipped languages.
+
+**Required.** A gate phrase that is compared must come from the same message catalogue as the
+instruction that requests it. Better still: do not gate on a typed phrase at all — require an
+explicit export first, or a hold-to-confirm. If a typed phrase is kept, the comparison reads
+`t('settings.confirmPhrase')` and the test asserts it in **both** locales.
+
+---
+
+<a id="p-22"></a>
+
+## P-22 🟠 · Delete-all dialog promises more than it delivers
+
+**Evidence.** The dialog lists what will be destroyed
+(`settings-view.tsx:291-294` → `ui.settings.allMonthsData`, `allInstallmentsData`,
+`allCategories`, `allCreditCards`). But `lib/expense-store.ts:1706-1715`:
+
+```ts
+deleteAllData: () => {
+  set({
+    monthlyData: {}, installments: [], notes: [], goals: [],
+    currentMonth: getCurrentMonth(),
+    currentYear: new Date().getFullYear().toString(),
+  })
+},
+```
+
+`categories` and `creditCards` are **not** reset. A user who "deletes all data" to start
+clean keeps every custom category and every credit card.
+
+**Required.** Delete-all resets every store to its initial state, categories back to the 11
+defaults and cards to empty. A test asserts the post-condition field by field, so the copy
+and the code cannot drift apart again.
+
+---
+
+<a id="p-01"></a>
+
+## P-01 🔴 · Goals and savings entries have no persistence path
+
+**Evidence.** `amplify/data/resource.ts` defines `Workspace`, `UserProfile`, `Invite`,
+`Category`, `CreditCard`, `MonthlyData`, `Income`, `Expense`, `Installment`, `Note`.
+
+There is **no `Goal` model and no `SavingsEntry` model.** The store says so plainly at
+`lib/expense-store.ts:852-854`:
+
+```ts
+// TODO: SavingsEntry and Goal are stored locally only.
+// Cloud sync (Amplify) for these types is not yet implemented.
+```
+
+and `lib/adapters/types.ts:157-159` reduces the update payload to nothing:
+
+```ts
+export type MonthlyDataUpdate = Record<string, never>
+```
+
+**Consequence in cloud mode, today:** goals and savings entries live only in one browser's
+localStorage. The second workspace member never sees them. Clearing site data destroys them
+with no backup. Worse, `loadWorkspace()` (`:1804-1811`) overwrites `monthlyData` wholesale
+with cloud data whose `savingsEntries` are always empty — so a cloud refresh **erases local
+savings entries**. Two of the app's headline features are quietly the least durable data in
+it.
+
+**Required.** In Phase 1 this is moot — everything is local and equally durable. It becomes
+binding when sync is designed: **no entity ships to the cloud phase without a defined sync
+path.** The sync layer enumerates domain entities exhaustively and fails to compile when one
+is unhandled (a `switch` over a discriminated union with no `default`), rather than silently
+omitting it.
+
+---
+
+<a id="p-02"></a>
+
+## P-02 🔴 · Bulk deletions never reach the cloud
+
+**Evidence.** Every single-record mutation enqueues its cloud counterpart. The two bulk
+deletions do not:
+
+- `deleteYearData` (`lib/expense-store.ts:1672-1704`) — removes months, installments, and
+  notes from local state. **No `enqueue` call anywhere in the function.**
+- `deleteAllData` (`:1706-1715`) — same.
+
+A related gap: `deleteCreditCard` (`:1522-1554`) reassigns affected installments to another
+card in local state, then enqueues **only** the card deletion — never the installment
+updates. The cloud keeps pointing them at the deleted card.
+
+**Consequence.** A user deletes a year, then opens the app on another device or refreshes
+from the cloud, and the data returns. The deletion appears to have failed.
+
+**Required.** Deletion is a first-class sync operation, not an afterthought. Any state
+transition that is not expressible as a queued mutation must not exist. Prefer a sync model
+that diffs local against remote (ADR-003) so an operation cannot be forgotten by omission —
+which is exactly how these two were lost.
+
+---
+
+<a id="p-03"></a>
+
+## P-03 🔴 · The write queue loses mutations under concurrency
+
+**Evidence.** `lib/write-queue.ts`. The queue is a JSON array in localStorage, accessed
+read-modify-write:
+
+```ts
+export function enqueue(op) {
+  const queue = readQueue()          // read
+  queue.push({ ...op, ... })         // modify
+  saveQueue(queue)                   // write
+}
+
+export async function processQueue() {
+  const queue = readQueue()          // snapshot taken here
+  const remaining = []
+  for (const item of queue) {
+    try { await dispatch(item) }     // ← awaits; user keeps interacting
+    catch { ... }
+  }
+  saveQueue(remaining)               // ← overwrites with the STALE snapshot
+}
+```
+
+Any `enqueue` that happens during those `await`s is written into the array, and then
+`saveQueue(remaining)` overwrites it. **The mutation is lost with no error.**
+
+The window is not theoretical: the processor runs on a 30-second interval _and_ on every
+`window.focus` (`:165-178`), and each dispatch is a network round trip. A user typing an
+expense while a sync runs can lose it.
+
+Two further problems in the same file:
+
+- **Dead letters are invisible.** After 3 retries an item is moved to
+  `tempest-dead-letters` (`:70-75`) and nothing ever reads that key. The user is never told.
+- **`Workspace:update` touches are unbounded.** Nearly every mutation enqueues an extra
+  `{ model: 'Workspace', operation: 'update' }`, so the queue fills with redundant
+  activity touches that are never coalesced.
+
+**Required (cloud phase).** Persist the outbox transactionally — IndexedDB with a real
+transaction, not read-modify-write over a JSON blob. Process with a single-flight lock.
+Coalesce by `(model, id)`. Surface failures in the UI: a queue that can silently drop
+financial records is worse than no queue.
+
+---
+
+<a id="p-11"></a>
+
+## P-11 🟠 · Installments against a card that does not exist
+
+**Evidence.** `components/expense/installments.tsx`:
+
+```ts
+const [card, setCard] = useState<string>('')     // :38 — starts empty
+...
+if (!name || !totalInstallments || !amount) return   // :54 — card NOT validated
+addInstallment({ name, card, ... })                  // :56
+...
+setCard('nubank_pri')                                // :66 — legacy ID, no such card
+```
+
+Two bugs in one form. The submit guard omits `card`, so a plan can be created with
+`card: ''`. And the post-submit reset assigns `'nubank_pri'` — a hardcoded ID from before
+credit cards became user-configurable, surviving here and in the unused
+`lib/validations.ts:49` card enum. After creating one plan, the form's card selector holds a
+value that matches no card, and a second submit persists it.
+
+An installment with an unresolvable card renders with a fallback grey swatch and the literal
+label "Card Name" (`installments.tsx:195` falls back to `i('ui.creditCards.cardName')`), and
+is invisible to every per-card total.
+
+**Required.** `cardId` is required in the schema and validated before submit. Form state
+resets to empty, never to a literal. Invariant 6 in `03` holds at all times.
+
+---
+
+<a id="p-15"></a>
+
+## P-15 🟠 · Card usage compares lifetime spend to a monthly limit
+
+**Evidence.** `lib/expense-store.ts:1591-1611`:
+
+```ts
+getCardTotalCommitment: (cardId) =>
+  installments
+    .filter((i) => i.card === cardId)
+    .reduce((sum, i) => sum + i.amountPerInstallment * i.totalInstallments, 0)
+// ↑ the FULL value of every plan, across its entire life
+
+getCardUsagePercentage: (cardId) => (getCardTotalCommitment(cardId) / card.limit) * 100
+// ↑ divided by a limit documented as "monthly limit in BRL"
+```
+
+A single 12 × R$100 plan on a card with a R$1,000 limit reports **120% usage** while
+consuming R$100 of that limit per month. The figure is meaningless and alarming.
+
+The store already has the correct primitive next to it — `getCardUsageForMonth(cardId, month)`
+sums only the occurrences falling in one month — but the percentage does not use it.
+
+**Required.** Decide which question the UI answers and label it accordingly:
+
+- _"How much of this month's limit is committed?"_ → `usageForMonth(card, month) / limit`
+- _"How much do I still owe on this card?"_ → outstanding remainder, shown as an **amount**,
+  not as a percentage of a monthly limit
+
+Ship one, name it precisely, and test it against a multi-month plan.
+
+---
+
+<a id="p-16"></a>
+
+## P-16 🟠 · Card delete dialog contradicts the code
+
+**Evidence.** `en.json` → `ui.creditCards.confirmDeleteWarning`:
+
+> "This card has {count} active installment(s). **They will be deleted as well.**"
+
+`lib/expense-store.ts:1538-1540` does the opposite:
+
+```ts
+const updatedInstallments = installments.map((inst) =>
+  inst.card === id ? { ...inst, card: reassignToCardId! } : inst
+)
+```
+
+The installments are **reassigned**, and the store throws if no reassignment target is given.
+The UI even renders a "Reassign installments to:" selector
+(`ui.creditCards.reassignInstallments`) directly beneath the warning that says they will be
+deleted.
+
+**Required.** Copy is part of the feature. When behaviour and message disagree, that is a
+bug, not a typo. The new app's delete dialog states the reassignment and names the target
+card.
+
+---
+
+<a id="p-08"></a>
+
+## P-08 🟠 · Hardcoded strings and locale-blind formatting
+
+**Evidence.**
+
+- `components/expense/dashboard-view.tsx` imports `useTranslations` on line 4 and hardcodes
+  **every** visible string in Portuguese: `"Painel"` (:213), `"Media de Despesas Mensais"`
+  (:253), `"Renda vs Despesas"` (:445), `"Poupanca e Investimentos"` (:618), `"Pendencias
+Financeiras"` (:349), and every chart series name. The `ui.dashboard.*` keys exist,
+  translated, in both files — and are entirely unreferenced.
+- `components/expense/expense-form.tsx` — the same: `"Adicionar Despesa Fixa"` (:80),
+  `"Descricao"` (:88), `"Valor (R$)"` (:98), `"Salvar Despesa"` (:147) — while
+  `forms.expense.*` sits unused.
+- **All 36** `formatCurrency` / `formatShortCurrency` call sites pass no locale, so the
+  default `'pt-BR'`/`'BRL'` applies everywhere. `useLocale()` appears in exactly two files
+  (`settings-view.tsx`, `sync-card.tsx`), neither for money.
+- `formatShortCurrency` takes a locale parameter named `_locale` and **ignores it**
+  (`lib/formatters.ts:42`), hardcoding the symbol and a `.` decimal separator.
+- Store errors are Portuguese literals: `'Já existe um cartão com esse nome'` (:1468),
+  `'Cartão não encontrado'` (:1504, :1527).
+- Stray Portuguese in code comments and JSX: `// Seção: Preferências`
+  (`settings-view.tsx:128`), `"Todos os parcelamentos ativos"` (`installments.tsx:251`).
+
+Several accented characters are also simply missing (`"Media"`, `"Mes"`, `"Poupanca"`,
+`"Distribuicao"`, `"Variaveis"`), so the Portuguese is wrong _as Portuguese_ too.
+
+**Required.** ADR-006 in full: lint against JSX literals, CI message-parity check,
+locale-bound formatters with no default locale parameter, typed domain errors mapped to
+messages in the UI.
+
+---
+
+<a id="p-09"></a>
+
+## P-09 🟠 · Render-time `.sort()` mutates store state
+
+**Evidence.** `components/expense/expense-form.tsx:117-118`:
+
+```ts
+const categories = useExpenseStore((state) => state.categories)   // :42
+...
+{categories
+  .sort((a, b) => a.order - b.order)   // ← in-place mutation of store state, during render
+  .map(...)}
+```
+
+`Array.prototype.sort` mutates. This reorders the array held inside the Zustand store as a
+side effect of rendering a dropdown, without going through `set()`. Subscribers are not
+notified, so other components can hold a differently ordered view of the same array until
+something unrelated forces a re-render.
+
+`components/expense/installments.tsx:42` gets it right — `[...creditCards].sort(...)` — which
+shows the mistake is inconsistency, not ignorance.
+
+**Required.** Sorting is derived state: a selector or a `useMemo` over a copy. Enable
+`eslint-plugin-react-hooks` exhaustively and add a lint rule (or a code-review check) against
+bare `.sort()` / `.reverse()` / `.splice()` on values obtained from a store selector.
+
+---
+
+<a id="p-04"></a>
+
+## P-04 🟡 · One action fans out into 25 records and 26 mutations
+
+**Evidence.** `addFixedExpenseWithPropagation` (`lib/expense-store.ts:1099-1173`) writes the
+expense to the current month plus `getFutureMonths(month, 24)` — 25 records. Then:
+
+```ts
+allCreatedExpenses.forEach(({ expense: e, targetMonth }) => {
+  enqueue({
+    model: 'Expense',
+    operation: 'create',
+    data: {
+      /* 9 fields */
+    },
+  })
+})
+enqueue({ model: 'Workspace', operation: 'update', data: { id: workspaceId } })
+```
+
+25 queued network mutations plus a workspace touch, for one user action. `addIncome` with
+replication (`:663-744`) does the same. Editing the series re-enqueues all 25.
+
+A user with 10 recurring fixed expenses and 2 recurring incomes materialises ~300 records
+covering two years, in a single localStorage JSON blob that is parsed and re-serialised on
+every mutation.
+
+**Required.** Rule-based recurrence (`03`). One record per rule; occurrences derived on read.
+One user action produces one mutation.
+
+---
+
+<a id="p-07"></a>
+
+## P-07 🟡 · Recurrence silently stops after 24 months
+
+**Evidence.** `getFutureMonths(startMonth, count = 24)` (`lib/expense-store.ts:300-306`),
+called with the default from both propagation paths.
+
+A recurring salary added in July 2026 exists through July 2028 and then **vanishes** with no
+warning, no UI affordance, and no way to extend it other than re-creating it. The user
+discovers it by finding an empty month two years out.
+
+The i18n copy is honest about it (`"this income will be replicated for the next 24 months"`),
+which makes it a documented limitation rather than a hidden one — but it is still a rule
+expressed as a magic number in a helper's default argument.
+
+**Required.** Open-ended recurrence (`endMonth: null`). Expansion is bounded by the range
+being _viewed_, not by the range that was _written_.
+
+---
+
+<a id="p-06"></a>
+
+## P-06 🟡 · Navigating a year writes 12 empty months
+
+**Evidence.** `setCurrentMonth` (`lib/expense-store.ts:561-572`) calls `initializeYear(year)`,
+which creates all 12 months (`:624-653`) — and in cloud mode enqueues a `MonthlyData:create`
+for each one:
+
+```ts
+newMonths.forEach((month) => {
+  enqueue({ model: 'MonthlyData', operation: 'create', data: { id: month, workspaceGroup } })
+})
+```
+
+Merely _looking_ at a year writes 12 empty records locally and 12 mutations to the cloud.
+`addIncome`, `addExpense`, and `addSavingsEntry` each call `initializeYear` again as a
+precondition. `getAvailableYears` then reads those empty months back and offers the year in
+the selector — so browsing to 2031 permanently adds 2031 to the year list.
+
+**Required.** Reading is never a write. `getMonthData(m)` returns empty arrays for an unknown
+month without persisting anything; records appear when the user enters data. `availableYears`
+derives from months that actually contain data, plus the current year.
+
+---
+
+<a id="p-12"></a>
+
+## P-12 🟡 · Category names can normalise to an empty ID
+
+**Evidence.** `normalizeToKebabCase` (`lib/expense-store.ts:290-297`) strips diacritics,
+lowercases, converts whitespace to hyphens, then removes every non-word character. A name
+consisting only of emoji or punctuation — `"🎉"`, `"!!!"` — normalises to `''`.
+
+`addCategory` (`:1315-1351`) checks only for duplicates, so a category with `id: ''` is
+created. It cannot be matched by `getCategoryById`, and any expense assigned to it falls back
+to `other`.
+
+**Required.** Validate the _derived ID_, not just the input: reject empty, reject collisions
+with the reserved system ID, reject collisions with default-category IDs (which would shadow
+an i18n key). Return a typed error the UI can explain.
+
+---
+
+<a id="p-14"></a>
+
+## P-14 🟡 · Two ID generators for one concept
+
+**Evidence.** The store generates recurring group IDs with
+`crypto.randomUUID()` (`lib/expense-store.ts:287`). A component generates them with
+`Math.random().toString(36).substring(2, 9)` (`monthly-view.tsx:62`) — 7 base-36 characters,
+comfortably collidable, and reachable as a fallback in the edit path.
+
+Sample data uses a third scheme (`:328`), seeded from `Math.sin` for determinism.
+
+**Required.** One `newId()` in `domain/`, `crypto.randomUUID()` everywhere. Test seeding uses
+an injected generator, not a parallel implementation.
+
+---
+
+<a id="p-17"></a>
+
+## P-17 🟡 · Two parallel APIs for savings entries
+
+**Evidence.** `lib/expense-store.ts:855-938` exposes both month-scoped operations
+(`addSavingsEntry(month, …)`, `updateSavingsEntry(month, …)`, `removeSavingsEntry(month, …)`)
+and global-by-ID operations (`updateSavingsEntryById`, `removeSavingsEntryById`) that loop
+over every month hunting for the entry.
+
+Both are live: the Monthly view uses the month-scoped ones, the goal detail sheet uses the
+by-ID ones. Two code paths, two sets of edge cases, one concept.
+
+**Required.** One API. Since an entry knows its own month, ID-scoped operations are the
+better primitive; month-scoped ones become thin conveniences over them, or disappear.
+
+---
+
+<a id="p-18"></a>
+
+## P-18 🟡 · Goal status `ahead` does not mean ahead
+
+**Evidence.** `lib/goal-utils.ts:64-67`:
+
+```ts
+if (confirmed >= goal.targetAmount) return 'ahead'
+if (monthlyNeeded <= goal.targetAmount / totalMonths) return 'on-track'
+if (confirmed >= expectedByNow * 0.9) return 'on-track'
+return 'behind'
+```
+
+`ahead` fires only when the target is already met — it means "reached, not yet marked
+complete". A goal genuinely ahead of its deadline schedule (60% saved with 80% of the time
+remaining) returns `on-track`. The status a user would most want to see does not exist.
+
+The `0.9` tolerance on the next line is also an unexplained magic number.
+
+**Required.** Either rename the state to `reached`, or implement `ahead` as a real schedule
+comparison. Name the tolerance as a documented constant. Cover all five states with tests
+using `vi.setSystemTime()`.
+
+---
+
+<a id="p-19"></a>
+
+## P-19 🟡 · Note dates render raw or in the system locale
+
+**Evidence.** `components/expense/notes-section.tsx`:
+
+```tsx
+{
+  note.date
+} // :185 → "2026-07-14" verbatim
+{
+  new Date(note.createdAt).toLocaleDateString()
+} // :189 → SYSTEM locale, not the app's
+{
+  note.createdMonth
+} // :195 → "2026-07" verbatim
+```
+
+Three date renderings, three different wrong answers: an ISO string shown to the user, a date
+formatted in the browser's locale rather than the app's, and a raw month key.
+
+**Required.** All dates render through the locale-bound formatter from `useFormatters()`
+(ADR-006). No `toLocaleDateString()` call sites outside `domain`/formatters.
+
+---
+
+<a id="p-20"></a>
+
+## P-20 🟠 · The numbers users make decisions on are untested
+
+**Evidence.** `__tests__/` contains 28 files. There is **no test for the dashboard**. Every
+aggregation in `dashboard-view.tsx` — average monthly expenses, month-over-month change,
+savings rate, total saved, category averages, the pie's top-6 selection, the payable /
+receivable totals — is computed in `useMemo` blocks inside a 717-line component and is
+verified by nothing.
+
+That is precisely where **P-13**, **P-21**, and **P-10** live: three wrong-number bugs, all in
+untested aggregation code.
+
+**Required.** Aggregations move to pure functions in `domain/`, and each ships with tests
+covering the empty case, the single-month case, the installment case, and the
+timezone-sensitive case. A number rendered to the user that is not covered by a unit test does
+not ship.
+
+---
+
+<a id="p-23"></a>
+
+## P-23 🟠 · The riskiest logic has its E2E tests skipped
+
+**Evidence.** `e2e/income-replication.spec.ts` contains three tests. All three are
+`test.skip`:
+
+```ts
+test.skip('should add income and replicate to future months', ...)
+test.skip('should update income with propagation', ...)
+test.skip('should delete income with propagation', ...)
+```
+
+Recurring propagation is the most intricate and highest-blast-radius logic in the app — it
+writes 25 records and edits ranges of months — and its entire end-to-end suite is disabled.
+The file still _looks_ like coverage in a directory listing.
+
+The same suite also hardcodes Portuguese UI text in `beforeEach`
+(`page.click('text=Visão Mensal')`), so it is locale-coupled and would fail under `en`.
+
+Additionally, `dashboard.spec.ts` and `navigation.spec.ts` both define a test named
+_"should filter dashboard by selected year"_ — duplicated coverage of one behaviour while
+goals, notes, savings, categories, and settings have **no** E2E coverage at all.
+
+**Required.** A skipped test is deleted or fixed — never left in place to look like coverage.
+CI fails on `.skip` / `.only` in committed specs. Selectors use `data-testid`, never
+user-visible text, so tests are locale-independent.
+
+---
+
+<a id="p-24"></a>
+
+## P-24 🟠 · Coverage excludes the code most likely to be wrong
+
+**Evidence.** `vitest.config.ts` enforces a 75% threshold, then excludes from measurement:
+
+```
+lib/workspace-client.ts     lib/write-queue.ts       lib/lambda-client.ts
+lib/amplify-config.ts       lib/use-amplify-data.ts  lib/migrations.ts
+lib/sync-store.ts           lib/hooks/**             lib/adapters/amplify/**
+components/workspace/**     components/amplify-provider.tsx
+```
+
+This excludes the write queue (**P-03**), the sync client (**P-01**, **P-02**), and the
+**data migrations** — the module that rewrites users' financial records in place. The 75%
+figure is measured over the safest code in the repo.
+
+`CLAUDE.md` already concedes the deeper flaw: _"The threshold only counts files that are
+imported by at least one test — new files with zero tests are invisible to it."_
+
+**Required.** Exclude only generated code and `components/ui/`. If a module is too hard to
+test, that is a design signal, not a reason to hide it from the report. Migrations get
+fixture-based round-trip tests before anything else. See `06`.

--- a/docs/migration/05-phase-plan.md
+++ b/docs/migration/05-phase-plan.md
@@ -67,10 +67,25 @@ ships to CI.
 - [ ] `README`, `CONTRIBUTING`, `LICENSE`, `CODE_OF_CONDUCT`, issue/PR templates
 - [ ] App shell: sidebar, navigation, theme toggle, year selector
 
+**Agent tooling** — full rationale in [`07-agent-tooling.md`](./07-agent-tooling.md).
+Install the enforcement layer **before** the convenience layer.
+
+- [ ] Hook: block hardcoded colour literals on Edit/Write → `07` Layer 1
+- [ ] Hook: block hand-written files in `components/ui/` (shadcn CLI only)
+- [ ] Hook: `Stop` fails when a code-changing session left `STATUS.md` untouched
+- [ ] Lint: no hex / arbitrary Tailwind values outside the token file
+- [ ] Lint: no bare `.sort()`/`.reverse()`/`.splice()` on selector output → **P-09**
+- [ ] Lint: no `new Date(<string>)` anywhere → **P-13**
+- [ ] Design-system project skill, versioned in the repo (build with `skill-creator`)
+- [ ] OpenWolf initialised — `STATUS.md` filled in, not left as a template
+- [ ] Playwright MCP wired up for screenshot review → `07` Layer 4
+
 **Exit criteria**
 `npm install && npm run dev` works on a clean clone with no accounts or env vars.
 `npm run quality && npm run test && npm run test:e2e` are green in CI.
 Every route is reachable by URL, back/forward works, a reload keeps you on the same screen.
+The enforcement layer is **proven, not assumed**: a deliberate hardcoded hex and a
+deliberate `.skip` are both rejected before the phase is ticked.
 
 ---
 

--- a/docs/migration/05-phase-plan.md
+++ b/docs/migration/05-phase-plan.md
@@ -1,0 +1,314 @@
+# 05 — Phase Plan
+
+The execution order. **This file is living state** — tick tasks as they complete and record
+blockers inline, so the next session resumes in one read.
+
+Each phase ends with a **shippable app**. Nothing is left half-wired between phases.
+
+---
+
+## Status
+
+| Phase | Name                         | State                                |
+| ----- | ---------------------------- | ------------------------------------ |
+| 0     | Foundation & shell           | ☐ not started                        |
+| 1     | Domain core & persistence    | ☐ not started                        |
+| 2     | Catalog — categories & cards | ☐ not started                        |
+| 3     | Ledger — income & expenses   | ☐ not started                        |
+| 4     | Installments                 | ☐ not started                        |
+| 5     | Savings & goals              | ☐ not started                        |
+| 6     | Notes                        | ☐ not started                        |
+| 7     | Monthly view assembly        | ☐ not started                        |
+| 8     | Dashboard                    | ☐ not started                        |
+| 9     | Settings, data & release     | ☐ not started                        |
+| 10    | Cloud sync                   | ⛔ blocked by design doc — see below |
+
+---
+
+## Dependency order
+
+```
+0 ──▶ 1 ──▶ 2 ──▶ 3 ──▶ 4 ──▶ 7 ──▶ 8 ──▶ 9
+             └──▶ 5 ──┘
+             └──▶ 6 ──┘
+```
+
+Phases 3, 5, and 6 all depend on 2 (categories) and on 1. Phase 4 depends on 2 (cards).
+Phase 7 assembles what 3–6 produced. **5 and 6 can be built in parallel with 4** if two
+agents are working; otherwise follow the numeric order.
+
+Each feature phase mounts its own panel into the `/months/$month` route as it is built, so
+the app is usable and demoable from Phase 3 onward.
+
+---
+
+## Phase 0 — Foundation & shell
+
+**Goal.** An empty but real application: it builds, routes, translates, themes, tests, and
+ships to CI.
+
+- [ ] Vite + React 19 + TypeScript (`strict`, `noUncheckedIndexedAccess`)
+- [ ] TanStack Router with the route tree from ADR-002; every route renders a placeholder
+- [ ] Tailwind v4 + the new brand tokens in `globals.css`
+- [ ] shadcn/ui initialised — **port primitives on first use, not wholesale** (the old repo
+      vendors 63; the app uses a fraction)
+- [ ] `use-intl` provider; `messages/en.json` + `pt.json` copied over verbatim
+- [ ] Locale detection: `localStorage` → `navigator.language` → `pt`
+- [ ] Theme: `prefers-color-scheme` + explicit override + blocking inline script (no flash).
+      **No `next-themes`, no `mounted` gate** — that gate is an SSR workaround with nothing
+      left to work around → ADR-001, **F-13**
+- [ ] Vitest + Testing Library + the custom render wrapper (i18n provider included)
+- [ ] **`TZ='America/Sao_Paulo'` set in the Vitest config and in CI** → **P-13**
+- [ ] Playwright, one smoke spec: app loads, sidebar renders, routes navigate
+- [ ] ESLint: `react/jsx-no-literals` with a curated allowlist → **P-08**
+- [ ] CI on pull requests, **no secrets** (must pass for fork PRs) → ADR-007
+- [ ] CI check: message-file key parity + no unreferenced keys → **P-08**
+- [ ] CI check: no `.skip` / `.only` in committed specs → **P-23**
+- [ ] `README`, `CONTRIBUTING`, `LICENSE`, `CODE_OF_CONDUCT`, issue/PR templates
+- [ ] App shell: sidebar, navigation, theme toggle, year selector
+
+**Exit criteria**
+`npm install && npm run dev` works on a clean clone with no accounts or env vars.
+`npm run quality && npm run test && npm run test:e2e` are green in CI.
+Every route is reachable by URL, back/forward works, a reload keeps you on the same screen.
+
+---
+
+## Phase 1 — Domain core & persistence
+
+**Goal.** The data foundation, fully tested, with nothing rendering it yet.
+
+- [ ] `domain/money.ts` — `Cents`, parse, format, arithmetic → ADR-005
+- [ ] `domain/month.ts` — `MonthKey`, parse, offset, diff, range, previous/next.
+      **Local `Date` constructor only; never `new Date(string)`** → **P-13**
+- [ ] `domain/ids.ts` — one `newId()` using `crypto.randomUUID()` → **P-14**
+- [ ] Branded types + boundary parsers for `Cents`, `MonthKey`, `IsoDate` → `03`
+- [ ] Store skeletons: `ledger`, `catalog`, `planning` (Zustand + Immer) → ADR-004
+- [ ] `persistence/db.ts` — IndexedDB via the `persist` middleware, async, debounced
+- [ ] `persistence/migrate.ts` — versioned registry, **pure** migrations, backup + retention
+- [ ] JSON **export** — full state, versioned, human-readable
+- [ ] JSON **import** — validate-then-commit, all-or-nothing → `03`
+- [ ] **Importer for old Tempest localStorage data**, including recurrence reconstruction
+      from `recurringGroupId` and the cents conversion → `03`
+
+**Exit criteria**
+`domain/` is 100% covered and has no React, storage, or i18n imports.
+Round-trip test: export → wipe → import → deep-equal.
+Old-app fixture imports cleanly, **including a series whose value changes mid-way** → `03`.
+Every invariant in `03` has a test.
+
+---
+
+## Phase 2 — Catalog: categories & credit cards
+
+**Goal.** The configuration surface everything else references. → **F-05**, **F-06**
+
+- [ ] Category CRUD, 11 defaults, `other` as the protected system category
+- [ ] Dual-label resolution `customLabel ?? t('categories.' + id)` → `03`
+- [ ] Colour palette picker + Lucide icon picker (shadcn primitives only)
+- [ ] Drag-and-drop reorder; `order` contiguous from 0
+- [ ] Delete reassigns expenses to `other` — never deletes them
+- [ ] ID normalisation **with derived-ID validation** → **P-12**
+- [ ] Credit card CRUD, colour, optional limit (`null` ≠ `0`)
+- [ ] Card reorder
+- [ ] Card delete with **reassignment**, and copy that says so → **P-16**
+- [ ] Card usage: pick one well-defined metric and name it precisely → **P-15**
+- [ ] Typed domain errors, mapped to i18n in the UI → **P-08**
+
+**Exit criteria**
+`/categories` and `/cards` fully usable. No `.sort()` on selector output → **P-09**.
+Render test for every Radix-based dialog and select. E2E smoke for both routes.
+
+---
+
+## Phase 3 — Ledger: income & expenses
+
+**Goal.** The core of the app, on a rule-based recurrence model. → **F-02**, **F-03**
+
+- [ ] `domain/recurrence.ts` — `Recurrence`, expansion for a month, exceptions field → `03`
+- [ ] **One** recurrence implementation shared by income and fixed expenses
+- [ ] Income CRUD within a month
+- [ ] Expense CRUD, fixed and variable, with category assignment
+- [ ] Recurring create → **one rule, not 25 rows** → **P-04**
+- [ ] Edit-from-month → close the old rule, open a new one → `03`
+- [ ] Delete-from-month → set `endMonth`, or delete when at the start
+- [ ] Convert single ↔ recurring
+- [ ] **Open-ended recurrence** — no 24-month horizon → **P-07**
+- [ ] Forms: zod schema + `@hookform/resolvers`, messages from i18n → ADR-006
+- [ ] Currency input per `CLAUDE.md` conventions; `autoComplete="off"` on non-login text
+- [ ] Income and expense panels mounted into `/months/$month`
+
+**Exit criteria**
+Recurrence is covered by unit tests for: create, edit-from-middle, delete-from-middle,
+convert both ways, and expansion beyond 24 months.
+**E2E for replication exists and is not skipped** → **P-23**.
+History is never rewritten by a forward edit.
+
+---
+
+## Phase 4 — Installments
+
+**Goal.** Multi-month card purchases, projected rather than stored. → **F-04**
+
+- [ ] `domain/installments.ts` — occurrence-in-month, derived, never persisted
+- [ ] Create with **required** card, 2–48 validated in the schema → **P-11**
+- [ ] Form reset clears to empty — no literal card IDs → **P-11**
+- [ ] Delete; decide edit explicitly (implement, or state its absence in the UI)
+- [ ] Projection into month totals and the category breakdown, under the **`installment`**
+      category → **P-10**
+- [ ] Panel mounted into `/months/$month`
+
+**Exit criteria**
+A plan starting in month _M_ appears in exactly `totalInstallments` consecutive months,
+numbered 1..n. A month containing an installment shows an `installment` breakdown entry,
+**not** `other` → **P-10**. Card reassignment on delete keeps every plan resolvable.
+
+---
+
+## Phase 5 — Savings & goals
+
+**Goal.** Reserves and the goals they feed. → **F-07**, **F-08**
+
+- [ ] Savings entry CRUD with a **single** API → **P-17**
+- [ ] `confirmed` flag; confirmed vs forecast treated distinctly throughout
+- [ ] Goal CRUD, icon, colour, target, optional deadline
+- [ ] `domain/goals.ts` — port `lib/goal-utils.ts` near-verbatim, converted to cents
+- [ ] Progress from **confirmed entries only**; forecast shown separately
+- [ ] Complete / reactivate; `completedAt` set iff completed (invariant 10)
+- [ ] Deleting a goal unlinks entries without deleting them
+- [ ] Resolve the `ahead` status: rename to `reached`, or implement it properly → **P-18**
+- [ ] Deadline picker rejects past months (per `CLAUDE.md`)
+- [ ] `/goals` and `/goals/$goalId` routes (the detail sheet becomes addressable)
+
+**Exit criteria**
+All five goal statuses covered by tests using `vi.setSystemTime()`.
+`targetAmount = 0` and a deadline in the current month are both covered.
+Deleting a goal preserves its savings entries.
+
+---
+
+## Phase 6 — Notes
+
+**Goal.** Month-scoped reminders that follow the user forward. → **F-09**
+
+- [ ] Note CRUD, value + direction, event date, persistent, done
+- [ ] **One** implementation of the visibility rule, in `domain/notes.ts` → `03`
+- [ ] Carried-forward notes pinned and badged
+- [ ] Inline done toggle
+- [ ] All dates through the locale-bound formatter → **P-19**
+- [ ] Decide whether `value: 0` is valid, and align the list and dashboard filters → **F-09**
+- [ ] Panel mounted into `/months/$month`
+
+**Exit criteria**
+Visibility rule tested across origin month, future months, done, and not-persistent.
+No raw ISO string and no `toLocaleDateString()` outside the formatters.
+
+---
+
+## Phase 7 — Monthly view assembly
+
+**Goal.** The panels become one coherent screen. → **F-11**
+
+- [ ] Layout matching the redesign: summary, left column, expense lists, notes
+- [ ] `domain/totals.ts` — **one** `monthExpenseTotal`, used everywhere → **P-21**
+- [ ] Summary cards: income, expenses, reserves, net balance
+- [ ] Month-over-month change using the **same** total on both sides → **P-21**
+- [ ] `0` as a valid previous-month baseline, not "no data" → **F-11**
+- [ ] Category breakdown, installments included
+- [ ] Month selector driving the URL → ADR-002
+
+**Exit criteria**
+A month with installments compared against an identical previous month reports **0%**.
+Previous-month resolution is correct under `TZ='America/Sao_Paulo'` → **P-13**.
+No blank frame on first paint — no `null` return while a month "initialises" → **P-06**.
+
+---
+
+## Phase 8 — Dashboard
+
+**Goal.** The analytics screen, rebuilt as tested pure functions plus thin charts. → **F-10**
+
+- [ ] Every aggregation as a pure function in `domain/analytics.ts`, each tested → **P-20**
+- [ ] Stat tiles: average expenses, MoM change, total saved, savings rate
+- [ ] Pending notes panel (payable / receivable)
+- [ ] Charts: income vs expenses, fixed vs variable, category distribution, savings trend
+- [ ] Category averages grid
+- [ ] **Every string from i18n** — `ui.dashboard.*` keys finally used → **P-08**
+- [ ] Month labels from `monthsShort.*` or the locale-bound formatter → **P-13**
+- [ ] One component per chart; no 700-line files
+- [ ] Route lazy-loaded (recharts is heavy)
+- [ ] Decide the pie's top-6 story: add an "other" bucket or label it as top-N → **F-10**
+- [ ] Document or fix the per-row denominator in category averages → **F-10**
+- [ ] **No `isHydrated` gate** — there is no server render to mismatch → ADR-001
+
+**Exit criteria**
+Every rendered number is covered by a unit test, including the empty, single-month, and
+installment cases → **P-20**. Zero hardcoded strings. Charts readable in light and dark.
+
+---
+
+## Phase 9 — Settings, data & release
+
+**Goal.** Data ownership, and a real 1.0. → **F-12**
+
+- [ ] Language switch **without a page reload**; one source of truth for locale
+- [ ] Export / import wired into the UI (built in Phase 1) → **F-12**
+- [ ] **Import from old Tempest** as a guided flow, not a hidden dev tool
+- [ ] Delete year, delete all — copy matching behaviour **exactly** → **P-22**
+- [ ] Delete-all resets categories and cards too, or says it does not → **P-22**
+- [ ] Confirmation phrase from i18n, verified in **both** locales → **P-05**
+- [ ] Prompt an export before any destructive action
+- [ ] PWA: manifest, service worker, offline shell, installable
+- [ ] Accessibility pass: keyboard navigation, focus traps, contrast, labels
+- [ ] Performance: route-level splitting, bundle budget in CI
+- [ ] `README` with screenshots, and a real `CHANGELOG`
+
+**Exit criteria**
+A user can move from the old app to the new one **without losing data**, and can get their
+data back out again. The destructive-confirmation E2E passes in `en` **and** `pt` → **P-05**.
+The app works fully offline after first load.
+
+---
+
+## Phase 10 — Cloud sync ⛔
+
+**Blocked.** Do not start until a design document exists and is reviewed.
+
+Per ADR-003, sync is designed against a **finished** local app. The old implementation is a
+catalogue of what not to do; that catalogue is the input to the design, not the design.
+
+**The design document must answer, before any code:**
+
+1. What is the conflict model? Last-write-wins per field, per record, or CRDT? The old app
+   asked the user to discard one entire dataset — decide if that is acceptable.
+2. What is the sync unit? An outbox of operations, or a state diff? ADR-003 recommends a
+   diff, because omission is what lost bulk deletes → **P-02**.
+3. How does every entity get a sync path, enforced at compile time? → **P-01**
+4. How is the outbox made concurrency-safe and its failures made visible? → **P-03**
+5. How does one user action stay one mutation? → **P-04**
+6. Does multi-user collaboration stay in scope? The old model capped a workspace at 2
+   members. If it is dropped, sync becomes single-user multi-device and dramatically simpler.
+7. Which backend? Deferring this decision was the point of ADR-003 — decide it with the
+   finished local model in hand, not before.
+
+**Prerequisite:** Phase 9 complete and released.
+
+---
+
+## Session protocol
+
+At the **start** of a session:
+
+1. Read `README.md`, then this file's Status table.
+2. Pick the first unticked task in the current phase.
+3. Read that feature's section in `02` and its linked entries in `04`.
+
+At the **end** of a session:
+
+1. Tick what is done. Add a dated note for anything blocked, with the reason.
+2. Update the Status table if the phase changed state.
+3. Commit. A phase is never left with a half-wired feature.
+
+**If a phase cannot complete**, finish every other task in it, then record precisely what is
+outstanding and why. Do not advance the Status table past a phase with open work — and do not
+quietly narrow a phase's scope to make it fit.

--- a/docs/migration/06-quality-bar.md
+++ b/docs/migration/06-quality-bar.md
@@ -1,0 +1,243 @@
+# 06 — Quality Bar
+
+The definition of done. Read before opening a pull request.
+
+The goal is **absolute quality without ceremony**: a small number of rules that are actually
+enforced, rather than a long list that is aspirational. Everything here is either
+machine-checked or takes under a minute to verify by hand.
+
+---
+
+## Definition of done
+
+A feature is done when **every** box is ticked. Not most.
+
+- [ ] Behaviour matches its section in `02`, including the listed edge cases
+- [ ] Every pitfall linked from that section is verified as **not reproduced**
+- [ ] Zero hardcoded user-visible strings; keys exist in `en.json` **and** `pt.json`
+- [ ] Pure logic lives in `domain/` and is unit tested, branches included
+- [ ] Every Radix-based component has a render test that opens it
+- [ ] The route has an E2E smoke test driving the primary user action
+- [ ] `npm run quality` passes
+- [ ] `npm run test` passes
+- [ ] `npm run test:e2e` passes
+- [ ] A screenshot of the new UI has been reviewed against an existing screen
+- [ ] The phase-plan task is ticked in `05`
+
+---
+
+## Testing
+
+### The layers, and what belongs in each
+
+| Layer                  | Covers                                                            | Rule                                                                                             |
+| ---------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| **Domain** (`domain/`) | Money, months, recurrence, installments, goals, totals, analytics | Pure functions. No React, no storage, no i18n, no mocks. Target 100%.                            |
+| **Store**              | Actions, invariants, state transitions                            | Real store, no mocked internals. Assert the resulting state, not the calls made.                 |
+| **Component**          | Rendering, interaction, a11y                                      | Testing Library through the custom i18n render wrapper. Query by role and label, never by class. |
+| **E2E** (Playwright)   | One primary flow per route                                        | `data-testid` selectors only — never user-visible text (→ **P-23**).                             |
+
+### Non-negotiable rules
+
+1. **A number rendered to the user is covered by a unit test.** Three of the worst bugs in
+   the old app (**P-13**, **P-21**, **P-10**) are wrong numbers in untested `useMemo` blocks.
+   If a value reaches the screen, a test asserts it.
+
+2. **Tests run under a non-UTC timezone.** `TZ='America/Sao_Paulo'` in the Vitest config and
+   in CI. This is the single check that catches the entire **P-13** family, and the app's
+   primary market is in that timezone anyway.
+
+3. **`vi.setSystemTime()` for anything that reads the clock.** Goal status, "current month"
+   defaults, `createdAt`. A test that passes only in July is not a test.
+
+4. **Every Radix primitive gets a render test.** Radix enforces runtime invariants
+   TypeScript cannot see — `SelectItem` may not have `value=""`, `Dialog` needs a title for
+   a11y. Only rendering surfaces them.
+
+   ```tsx
+   it('renders without crashing', async () => {
+     render(<CategoryFormDialog open onOpenChange={() => {}} />)
+     expect(await screen.findByRole('dialog')).toBeInTheDocument()
+   })
+   ```
+
+5. **No skipped tests in `main`.** A `.skip` is deleted or fixed. CI fails on `.skip` and
+   `.only` in committed specs. The old repo's entire replication E2E suite sat skipped while
+   looking like coverage (→ **P-23**).
+
+6. **Migrations get fixture round-trip tests before they ship.** The code that rewrites a
+   user's financial history is the last place to skip tests — and the old repo excluded it
+   from coverage entirely (→ **P-24**).
+
+7. **Coverage excludes only generated code and `components/ui/`.** Nothing else. A module
+   that is hard to test is a design problem to fix, not a line to add to an exclude list.
+
+   > Treat the coverage percentage as a smoke alarm, not a goal. It only measures files
+   > imported by at least one test, so a brand-new untested module is invisible to it. Write
+   > tests because the logic needs them.
+
+### Regression tests for pitfalls
+
+When migrating a feature, add a test that would **fail** if its pitfall were reintroduced.
+These are the highest-value tests in the suite:
+
+| Pitfall  | The test                                                                                                |
+| -------- | ------------------------------------------------------------------------------------------------------- |
+| **P-13** | Under `TZ=America/Sao_Paulo`: the label for `2026-07` is July; `previousMonth('2026-07') === '2026-06'` |
+| **P-21** | Identical months containing installments report **0%** change                                           |
+| **P-10** | A month with an installment yields an `installment` breakdown entry, not `other`                        |
+| **P-05** | The destructive confirmation succeeds in **both** locales                                               |
+| **P-22** | After delete-all, categories are back to the 11 defaults and cards are empty                            |
+| **P-07** | A recurrence started in month _M_ still resolves at _M + 36_                                            |
+| **P-06** | Reading an unknown month persists nothing                                                               |
+| **P-12** | A category named `"🎉"` is rejected                                                                     |
+| **P-15** | A 12 × R$100 plan on a R$1,000-limit card reports a sane usage figure                                   |
+
+---
+
+## Internationalisation
+
+Enforced by ADR-006. In practice:
+
+1. **No user-visible literal in JSX.** `react/jsx-no-literals` is on, with a curated
+   allowlist for symbols and numerals. This is what makes **P-08** impossible to repeat —
+   the old app had a fully translated dashboard key set sitting unused above 700 lines of
+   hardcoded Portuguese.
+
+2. **CI checks message files.** Key sets in `en.json` and `pt.json` must match exactly, and
+   a key defined but never referenced fails the build. That check would have caught both the
+   two `pt`-only keys and the dead `ui.dashboard.*` set.
+
+3. **Formatters are locale-bound and have no defaults.**
+
+   ```ts
+   // ✗ the old signature — the default is why all 36 call sites are pt-BR
+   formatCurrency(value: number, locale: SupportedLocale = 'pt-BR', ...)
+
+   // ✓ locale is bound once, at the provider
+   const format = useFormatters()
+   format.currency(cents)
+   ```
+
+   `formatCurrency` outside a bound context is a type error. A parameter that is ignored —
+   as `_locale` is in the old `formatShortCurrency` — must not exist.
+
+4. **No `toLocaleDateString()` outside the formatters.** No raw ISO string reaches the
+   screen (→ **P-19**).
+
+5. **Domain and store code never produce user-facing text.** They throw typed errors; the UI
+   maps error types to messages. No more `throw new Error('Cartão não encontrado')`.
+
+6. **Any compared phrase comes from the message catalogue** — the same one that instructs the
+   user (→ **P-05**).
+
+7. **Both locales are exercised in E2E.** At minimum the destructive-confirmation flow.
+
+---
+
+## UI conventions
+
+These carry over from `CLAUDE.md` because they encode real, expensive lessons.
+
+**Before building a form or modal**
+
+1. Read at least two existing equivalents first. Copy their structure and spacing; do not
+   invent a layout.
+2. **shadcn/ui primitives only.** Never hand-roll a colour picker, icon selector, dropdown,
+   or date input. Custom primitives are how UI drifts.
+3. Field conventions:
+   - Currency: integer-valued input (ADR-005), never `step="0.01"` — which
+     `expense-form.tsx:102` does today, against the project's own rule
+   - Deadlines: `<Input type="month">` or a `Select` constrained to future months. Never
+     allow a past deadline.
+   - Non-login text inputs: `autoComplete="off"` so password managers do not hijack them
+
+**Visual validation is mandatory**
+
+An agent has no eyes by default. Before marking UI work done:
+
+```bash
+npm run dev &
+# drive the screen with Playwright, capture a screenshot, review it
+# fix, repeat until it matches the rest of the app
+kill %1
+```
+
+Then open an existing comparable screen beside it and check spacing, type scale, and
+component sizing. A form is not done until a screenshot confirms it.
+
+**Charts** must be legible in light and dark, use the brand palette, and get their labels
+from i18n — never from a hardcoded series name.
+
+---
+
+## Code conventions
+
+- `type` over `interface`, except where an interface is genuinely extended
+- Explicit prop types on every component
+- **Never mutate a value obtained from a store selector.** No bare `.sort()`, `.reverse()`,
+  `.splice()` — copy first (→ **P-09**)
+- Sorting and filtering are derived state: a selector or `useMemo`, never inline in JSX
+- One `newId()`, `crypto.randomUUID()` everywhere (→ **P-14**)
+- No magic strings for IDs — reference the constant (→ **P-10**)
+- No magic numbers for business rules — name them (→ **P-07**, **P-18**)
+- Anything longer than a few lines inside a store action belongs in `domain/`
+- All code, comments, identifiers, and commits in **English** (→ ADR-007)
+
+---
+
+## Pull request checklist
+
+```markdown
+## What
+
+<one line>
+
+## Phase / Feature
+
+Phase N · F-xx
+
+## Pitfalls verified not reproduced
+
+- [ ] P-xx — <how it was verified>
+
+## Checks
+
+- [ ] npm run quality
+- [ ] npm run test
+- [ ] npm run test:e2e
+- [ ] Screenshot reviewed against an existing screen
+- [ ] Strings in both en.json and pt.json
+- [ ] Phase-plan task ticked in docs/migration/05-phase-plan.md
+```
+
+---
+
+## Anti-patterns
+
+Specific things that produced the defects in `04`. Do not do them.
+
+| Anti-pattern                                              | Where it bit                                                                |
+| --------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `new Date(someString)` for a date-only value              | **P-13** — off-by-one month across the whole dashboard                      |
+| The same total computed two ways in two places            | **P-21** — wrong month-over-month percentage                                |
+| A default-argument magic string for an ID                 | **P-10** — installments filed under a dead category                         |
+| A compared literal that has a translated counterpart      | **P-05** — English users locked out of deletion                             |
+| UI copy written independently of the code                 | **P-16**, **P-22** — dialogs that describe behaviour the code does not have |
+| Business logic in a `useMemo` inside a 700-line component | **P-20** — untested numbers                                                 |
+| An exclude list instead of a testable design              | **P-24** — the riskiest modules unmeasured                                  |
+| Materialising a rule into rows                            | **P-04**, **P-07** — 25 writes per action, silent 24-month cliff            |
+| Reading state that writes state                           | **P-06** — browsing a year persists 12 empty months                         |
+| An abstraction built for a backend that is not there yet  | ADR-003 — 15 of 17 methods are `return Promise.resolve()`                   |
+
+---
+
+## When something is genuinely blocked
+
+Do not ship a half-feature to keep the phase moving, and do not silently shrink the scope.
+
+1. Finish everything in the phase that is **not** blocked.
+2. Record the blocker in `05` with a date and the reason.
+3. Say plainly what is outstanding.
+
+Scaling work down is the maintainer's call, not the agent's.

--- a/docs/migration/06-quality-bar.md
+++ b/docs/migration/06-quality-bar.md
@@ -37,6 +37,17 @@ A feature is done when **every** box is ticked. Not most.
 | **Component**          | Rendering, interaction, a11y                                      | Testing Library through the custom i18n render wrapper. Query by role and label, never by class. |
 | **E2E** (Playwright)   | One primary flow per route                                        | `data-testid` selectors only — never user-visible text (→ **P-23**).                             |
 
+### When tests get written
+
+**TDD in `domain/`, test-after in the UI.** Full reasoning in
+[`07-agent-tooling.md`](./07-agent-tooling.md) Layer 5.
+
+- **`domain/`** — pure functions, no mocks, and the spec already exists (the pitfall table
+  below is a ready-made list of failing tests). Write them red first. Enforced by a hook:
+  a Write to `domain/x.ts` is rejected when `domain/x.test.ts` does not exist.
+- **UI** — the design is discovered visually, so tests-first is guaranteed rework. The cycle
+  is `build → screenshot → review → render test → E2E smoke`.
+
 ### Non-negotiable rules
 
 1. **A number rendered to the user is covered by a unit test.** Three of the worst bugs in

--- a/docs/migration/07-agent-tooling.md
+++ b/docs/migration/07-agent-tooling.md
@@ -1,0 +1,258 @@
+# 07 — Agent Tooling
+
+The toolchain the migrating agent runs inside: what to install, what to enforce
+mechanically, and what to leave out.
+
+Read once when setting up the new repository (Phase 0). Revisit only when adding a tool.
+
+---
+
+## The organising principle
+
+> **A skill advises. A hook enforces.**
+
+A skill is context the model _may_ follow. A hook is code that runs whether the model wants
+it to or not. Everything in this guide that says "must" needs to be a hook, a lint rule, or
+a CI check — otherwise it is a suggestion, and suggestions decay.
+
+This is not theoretical. The old app had a complete, translated, 502-key i18n system and a
+dashboard with **every string hardcoded in Portuguese** (→ **P-08**). The infrastructure was
+right; nothing enforced its use. The same failure mode produced `.skip`ped E2E tests that
+still looked like coverage (→ **P-23**) and a 75% coverage threshold measured over the
+safest code in the repo (→ **P-24**).
+
+**Corollary: every tool costs context on every session.** A tool that does not prevent a
+specific failure listed in `04` is overhead. Be ruthless.
+
+---
+
+## Layer 1 — Enforcement (install first, Phase 0)
+
+This layer is the reason the new app will not repeat `04`. It is not optional and it is not
+a "later" item.
+
+### Hooks
+
+Configured in `.claude/settings.json`. Use the `update-config` skill to write them.
+
+| Hook                                         | Fires                      | Prevents                                                                         |
+| -------------------------------------------- | -------------------------- | -------------------------------------------------------------------------------- |
+| Block hardcoded colour literals              | `PreToolUse` on Edit/Write | The 20-hex palette hardcoded in the old store; drift from the design system      |
+| Block hand-written files in `components/ui/` | `PreToolUse` on Write      | Custom primitives instead of the shadcn CLI (`CLAUDE.md` rule, routinely broken) |
+| Require `STATUS.md` freshness                | `Stop`                     | Context loss between sessions — see Layer 2                                      |
+| Reject `.skip` / `.only` in specs            | `PreToolUse` + CI          | → **P-23**                                                                       |
+
+### Lint rules
+
+- `react/jsx-no-literals` with a curated allowlist → **P-08**
+- No hex literals or arbitrary Tailwind values (`bg-[#ef4444]`) outside the token file
+- No bare `.sort()` / `.reverse()` / `.splice()` on a store selector result → **P-09**
+- No `new Date(<string>)` anywhere → **P-13**
+
+### CI checks
+
+- Message-file key parity (`en.json` ↔ `pt.json`), and no key defined but unreferenced
+- `TZ='America/Sao_Paulo'` on the test job → **P-13**
+- Bundle-size budget
+
+> **Why this ordering.** Layers 2–4 are conveniences. Layer 1 is the only thing that makes
+> the quality bar in `06` real rather than aspirational.
+
+---
+
+## Layer 2 — Context and task management
+
+### OpenWolf — keep, with a caveat
+
+Long-term memory across sessions: `STATUS.md` (handoff), `cerebrum.md` (learnings,
+do-not-repeat), `anatomy.md` (token-efficient file index), `buglog.json`.
+
+**The caveat is honest and load-bearing.** In the old repo OpenWolf worked as _structure_
+but not as _habit_: `STATUS.md` sat as an unedited template for over a week and
+`cerebrum.md` held two entries, until both were filled in during the session that produced
+this guide. **Memory only pays off if something writes to it.**
+
+→ Enforce with the `Stop` hook in Layer 1: fail the turn if a session that modified code did
+not touch `STATUS.md`.
+
+### kanban-md — only with parallel agents
+
+File-based Kanban, one Markdown file per task, no server. Agent-first: `--compact` output,
+atomic `pick --claim` with cooperative locking and expiring claims, self-healing task IDs,
+and installable agent skills (`kanban-md skill install`).
+
+**Decide the boundary before installing it**, because it overlaps `05-phase-plan.md`:
+
+| File               | Role                                                    | Changes    |
+| ------------------ | ------------------------------------------------------- | ---------- |
+| `05-phase-plan.md` | **Strategy** — phases, exit criteria, dependency order  | Rarely     |
+| kanban board       | **Execution** — today's work units, claims, parallelism | Constantly |
+
+Two sources of truth for the same thing is worse than one. Its real differentiator is
+`pick --claim`, which only matters when **multiple agents work the same board
+concurrently**. One agent at a time → the phase plan alone is enough; skip it.
+
+### Ponytail — optional, and it conflicts with `06`
+
+A cross-agent discipline layer that pushes the model to ship the least code that solves the
+problem. Reported benefits are real (substantially less output code, lower cost).
+
+**But it is in direct tension with this project's quality bar.** `06` requires a unit test
+for every number rendered, a render test for every Radix primitive, and an E2E smoke test
+per route. That is a lot of output code — and it is precisely the code Ponytail is optimised
+not to write.
+
+If you install it, **exclude the domain layer and all test files from its scope** — in glob
+terms, `domain/` recursively plus every `*.test.*` file. Otherwise you save tokens by buying
+back **P-13**, **P-21**, and **P-20** — three defects that exist specifically because logic
+was untested.
+
+---
+
+## Layer 3 — Design system enforcement
+
+The new brand is the point of the rebuild, so drift here is the most expensive kind. Three
+levels, strongest first.
+
+### 1. Mechanical (Layer 1)
+
+The token lint and the `components/ui/` write-block above. This is what actually enforces.
+
+### 2. A project skill, written by you, versioned in the repo
+
+When output must follow **repo-owned** tokens, a project skill beats any generic plugin: it
+loads your tokens, logo, composition rules, and canonical examples into every session
+automatically. Build it with the **`skill-creator`** skill.
+
+It should encode:
+
+- The token set, and the rule that raw values are never used
+- Logo and brand-mark usage
+- Composition rules (which primitives compose, which never nest)
+- Two canonical examples — one form, one dialog — as the copy-from reference, which is the
+  `CLAUDE.md` "read two existing components first" rule made executable
+
+### 3. `/design-sync` + the `DesignSync` tool — only if your DS lives in Claude Design
+
+Keeps a local component library in sync with a Claude Design design-system project,
+**incrementally, one component at a time, never as a wholesale replace**.
+
+⚠️ **Verified limitation.** `DesignSync` needs design-system authorization via
+`/design-login`, which requires an interactive terminal and is **not available in Claude
+Code on the web**. If your design system lives in Claude Design, use its **"Send to Claude
+Code Web"** button to seed the project into the workspace, or provide the files directly.
+
+### Already available: the `design` plugin
+
+Enabled on this account. Two commands are relevant:
+
+- `/design:accessibility` — WCAG audit. Run per route in **Phase 9**.
+- `/design:handoff` — Figma → developer specs, if the redesign lives in Figma.
+
+---
+
+## Layer 4 — Visual verification
+
+`CLAUDE.md` already requires a screenshot review before UI is called done — but that
+currently depends on the agent remembering. Give it eyes properly.
+
+**Use Playwright MCP.** The project already uses Playwright for E2E, so this is one browser
+stack instead of two: navigate, fill, click, screenshot, wait for elements.
+
+**Not Chrome DevTools MCP** — it is for _debugging_ a browser (CDP: network timing,
+performance traces, memory, console) rather than _driving_ one. Add it later if performance
+profiling becomes a real need; it is not a Phase 0 concern.
+
+---
+
+## Layer 5 — Testing policy: TDD, selectively
+
+The direct answer: **TDD in `domain/`, test-after in the UI.** This is not a hedge — the two
+halves have genuinely different economics.
+
+### TDD in `domain/` — yes
+
+The conditions that make TDD pay are all present: pure functions, no mocks, and a **spec
+that already exists**. `06`'s pitfall-regression table is literally a list of executable
+cases that can be written before a single line of implementation:
+
+```
+previousMonth('2026-07') === '2026-06'         under TZ=America/Sao_Paulo   → P-13
+identical months with installments → 0% change                             → P-21
+a month with an installment → 'installment' entry, not 'other'             → P-10
+a recurrence started at M still resolves at M+36                           → P-07
+a category named "🎉" is rejected                                          → P-12
+```
+
+Five red tests before `domain/month.ts` exists. They lock the three wrong-number bugs out
+permanently.
+
+### TDD in the UI — no
+
+The design is new and gets discovered visually. Writing tests before knowing what the
+component became is guaranteed rework. The UI cycle is:
+
+```
+build → screenshot → review → render test → E2E smoke
+```
+
+### It needs enforcement either way
+
+Models naturally write implementation first and tests second; TDD is the inverse, so it
+**requires explicit enforcement** rather than good intentions. Make it a hook on `domain/`:
+reject a Write to `domain/x.ts` when `domain/x.test.ts` does not already exist.
+
+---
+
+## What not to install
+
+| Tool                                                              | Why not                                                                                                                                                                             |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Serena** (semantic code navigation)                             | Earns its context in legacy code — navigating an 1,887-line store by symbol. In a greenfield where `domain/` files are ~80 lines, Read/Grep is cheaper. Re-evaluate around Phase 8. |
+| **Chrome DevTools MCP**                                           | Debugging, not driving. Not a Phase 0 need (Layer 4).                                                                                                                               |
+| **Knowledge-work plugins** (`product-management`, `marketing`, …) | The available catalog targets knowledge work, not this project.                                                                                                                     |
+| **A second state/test framework**                                 | Zustand and Vitest are already the right size. Adding tools is how `components/ui/` grew to 63 vendored primitives.                                                                 |
+
+---
+
+## Summary
+
+| Tool                                          | Install when              | Why                                               |
+| --------------------------------------------- | ------------------------- | ------------------------------------------------- |
+| Hooks + token lint + CI checks                | **Phase 0**               | The only real enforcement                         |
+| Design-system project skill (`skill-creator`) | **Phase 0**               | Repo-owned tokens beat a generic plugin           |
+| OpenWolf                                      | **Phase 0**               | Proven — with the `Stop` hook forcing `STATUS.md` |
+| Playwright MCP                                | **Phase 0**               | Closes the visual loop; same stack as E2E         |
+| TDD in `domain/`                              | **Phase 1**               | Tests already written in `06`                     |
+| `design` plugin (`/design:accessibility`)     | Phase 9                   | WCAG per route                                    |
+| kanban-md                                     | Only with parallel agents | Otherwise `05` is enough                          |
+| Ponytail                                      | Optional                  | Exclude `domain/**` and tests from scope          |
+| Serena                                        | Re-evaluate Phase 8       | Low value in greenfield                           |
+
+---
+
+## Caveat
+
+The research behind this document covers **what these tools do**, not **them working
+together in the new repository** — which does not exist yet. Nothing here has been validated
+as an integrated stack.
+
+The one item that _was_ tested is `DesignSync`, and it failed for the reason documented in
+Layer 3. Treat the rest as a plan to verify during Phase 0: install Layer 1 first and prove
+it blocks a real hardcoded hex before trusting any of it.
+
+---
+
+## Sources
+
+- [Ponytail Inside Claude Code Is Really About Token Discipline](https://aikickstart.com.au/news/ponytail-inside-claude-code-token-discipline)
+- [Ponytail: The AI Coding Skill That Saves Tokens by Writing Less Code](https://www.alphamatch.ai/blog/ponytail-ai-coding-skill-2026)
+- [kanban-md — File-based Kanban for AI agents and humans](https://antopolskiy.github.io/kanban-md/)
+- [antopolskiy/kanban-md](https://github.com/antopolskiy/kanban-md)
+- [Claude Design System Skill: Use Claude Design, Build a Project Skill, or Vet a UI/UX Skill?](https://blog.laozhang.ai/en/posts/claude-design-system-skill)
+- [Design Systems in 2026: Turn Your System into a Claude Skill](https://www.designsystemscollective.com/design-systems-in-2026-turn-your-system-into-a-claude-skill-3dd4d8bf5feb)
+- [Claude Design June 2026: Design System Imports, Claude Code Sync](https://chatforest.com/builders-log/claude-design-june-2026-design-system-imports-code-sync-token-fix-builder-guide/)
+- [Playwright vs. Chrome DevTools MCP: Driving vs. Debugging](https://stevekinney.com/writing/driving-vs-debugging-the-browser)
+- [I Tested All 3 Browser Tools for Claude Code](https://ayyaztech.com/blog/chrome-devtools-mcp-vs-claude-in-chrome-vs-playwright)
+- [A Claude Code TDD Skill: Forcing Red-Green-Refactor Discipline](https://alexop.dev/posts/custom-tdd-workflow-claude-code-vue/)
+- [Claude Code and the Art of Test-Driven Development](https://thenewstack.io/claude-code-and-the-art-of-test-driven-development/)

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,0 +1,109 @@
+# Migration Guide
+
+This directory is the complete specification for rebuilding Tempest as a new, clean,
+open-source-from-day-zero application.
+
+It is written to be executed by an AI agent working **one feature at a time**, across many
+sessions, without losing quality or context between them.
+
+> **Scope note.** The new app has a new brand and a fully redesigned UI. The _functionality_
+> is intentionally unchanged. That is why this is called a migration and not a rewrite:
+> behaviour is the spec, code is not. Every improvement — i18n, tests, naming, structure —
+> is made **during** the migration of the part it belongs to, never as a follow-up pass.
+
+---
+
+## Read this first
+
+| #   | Document                                                   | Read when                                                       |
+| --- | ---------------------------------------------------------- | --------------------------------------------------------------- |
+| —   | **README.md** (this file)                                  | Always. Start of every session.                                 |
+| 01  | [`01-target-architecture.md`](./01-target-architecture.md) | Once, before writing any code. Then when touching structure.    |
+| 02  | [`02-feature-inventory.md`](./02-feature-inventory.md)     | Before migrating any feature. Read only that feature's section. |
+| 03  | [`03-domain-model.md`](./03-domain-model.md)               | Before touching types, store, or persistence.                   |
+| 04  | [`04-pitfalls.md`](./04-pitfalls.md)                       | Before migrating a feature — check its entries. Non-negotiable. |
+| 05  | [`05-phase-plan.md`](./05-phase-plan.md)                   | Start of every session, to know what phase you are in.          |
+| 06  | [`06-quality-bar.md`](./06-quality-bar.md)                 | Before opening a PR. Definition of done.                        |
+
+**Minimum read for one feature migration:** this README → the feature's section in `02` →
+its listed entries in `04` → `06`. That is roughly 400 lines, not the whole guide.
+
+---
+
+## The three rules
+
+Everything else in this guide is detail. These three are the guide.
+
+### 1. Behaviour is ported. Code is not.
+
+The old codebase is a **behavioural reference**, not a source to copy. When migrating a
+feature, read the old implementation to learn _what it does and which edge cases it
+handles_, then write the new implementation from the spec in `02` and the model in `03`.
+
+Copy-pasting from the old repo is the single most likely way to fail this migration,
+because the old code carries the exact defects catalogued in `04`.
+
+### 2. Every feature arrives complete or not at all.
+
+A feature is migrated when **all** of these are true — not four of five:
+
+- Behaviour matches the spec in `02`, including the listed edge cases.
+- Every user-visible string is in `en.json` **and** `pt.json`. Zero hardcoded copy.
+- Unit tests cover the logic branches; a render test exists for every Radix-based component.
+- An E2E smoke test drives the primary user action on the screen.
+- `npm run quality` and `npm run test` pass.
+- The relevant `04` pitfalls are verified as _not_ reproduced.
+
+Half-migrated features are worse than unmigrated ones: they look done and hide gaps.
+
+### 3. Local-first is the architecture, not a mode.
+
+The new app is a client-side application whose source of truth is the user's own device.
+Cloud sync is a **later, optional layer** added on top of a finished local app — it is not
+an abstraction to design around now.
+
+The old app inverted this: it defined a 17-method `StorageAdapter` interface shaped entirely
+around AWS Amplify, then implemented it locally with 15 methods that do nothing but
+`return Promise.resolve()`. Do not build that. See `01` for what to build instead.
+
+---
+
+## How to run one migration session
+
+```
+1. Read this README.
+2. Read 05-phase-plan.md → identify the current phase and the next unchecked task.
+3. Read that feature's section in 02-feature-inventory.md.
+4. Read the pitfall entries that section links to in 04-pitfalls.md.
+5. Implement. Write tests alongside, not after.
+6. Run: npm run quality && npm run test && npm run test:e2e
+7. Verify against the checklist in 06-quality-bar.md.
+8. Tick the task in 05-phase-plan.md. Commit.
+```
+
+If a step cannot be completed, **stop and record why in the phase plan** rather than
+shipping a partial feature and moving on.
+
+---
+
+## What this guide is not
+
+- It is not a design spec. The new visual design lives with the brand work; this guide
+  covers behaviour, data, and structure. Where the two meet (component conventions, form
+  field rules), `06` sets the constraints the design must be implemented within.
+- It is not a line-by-line port map. There is deliberately no "old file → new file" table,
+  because the target structure is different by design (see `01`).
+- It is not exhaustive about the old code's _implementation_. It is exhaustive about the
+  old code's _behaviour and defects_.
+
+---
+
+## Provenance
+
+Every factual claim in `02`, `03`, and `04` was verified against the Tempest codebase at
+the commit this guide was written from — file paths and line numbers are cited so they can
+be re-checked. Where the old code is wrong, `04` states the evidence and the required
+behaviour in the new app.
+
+If you find a discrepancy between this guide and the old code, the guide's _intent_ wins,
+but **record the discrepancy** — it usually means a behaviour was missed during mapping.

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -24,9 +24,11 @@ sessions, without losing quality or context between them.
 | 04  | [`04-pitfalls.md`](./04-pitfalls.md)                       | Before migrating a feature — check its entries. Non-negotiable. |
 | 05  | [`05-phase-plan.md`](./05-phase-plan.md)                   | Start of every session, to know what phase you are in.          |
 | 06  | [`06-quality-bar.md`](./06-quality-bar.md)                 | Before opening a PR. Definition of done.                        |
+| 07  | [`07-agent-tooling.md`](./07-agent-tooling.md)             | Once, when setting up the repo. Then only when adding a tool.   |
 
 **Minimum read for one feature migration:** this README → the feature's section in `02` →
 its listed entries in `04` → `06`. That is roughly 400 lines, not the whole guide.
+`07` is setup-time only — it is not part of the per-feature read path.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32057,9 +32057,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.5",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.5.tgz",
-      "integrity": "sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.30.0.tgz",
+      "integrity": "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -32782,12 +32782,12 @@
       }
     },
     "node_modules/@smithy/uuid": {
-      "version": "1.3.10",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.3.10.tgz",
-      "integrity": "sha512-r60ztUTPfPZMuzMiKJA/aZ02bEsuPxSFcwVMagidZB6QwgfabOvPDpvelLA1a0OSexVIxyy8xepFApmOhrGSkQ==",
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.3.14.tgz",
+      "integrity": "sha512-hqgnjAz/gX90Sy3lUFSOlwI3RV5H2KIXvWzHHPhsGeafwYyCTxh5k+1zoVdch2EkDdZ5K6uDYklA5lFzifeRJg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.5",
+        "@smithy/core": "^3.30.0",
         "tslib": "^2.6.2"
       },
       "engines": {


### PR DESCRIPTION
## Summary

Adds `docs/migration/` — an eight-document specification for rebuilding Tempest as a new, clean, open-source-from-day-zero application: new brand, redesigned UI, **same feature set**.

The guide is written to be executed by an AI agent **one feature at a time, across many sessions**, so it is structured around stable IDs (`F-xx` features, `P-xx` pitfalls, `ADR-xxx` decisions) and a single living state file, rather than as prose. The minimum read to migrate one feature is ~400 lines, not the whole guide.

| Doc | Contents |
|---|---|
| `README` | Index, the three rules, per-session read path |
| `01-target-architecture` | 7 ADRs, all closed |
| `02-feature-inventory` | 15 features (`F-01`..`F-15`) with behaviour and edge cases |
| `03-domain-model` | Canonical types, 10 invariants, old→new import map |
| `04-pitfalls` | 24 verified defects (`P-01`..`P-24`) with line-level evidence |
| `05-phase-plan` | Phases 0–10, checklists, exit criteria — **living state** |
| `06-quality-bar` | Definition of done |
| `07-agent-tooling` | The agent toolchain: what to install, what to enforce mechanically |

### Principal decisions

- **Vite + React 19 + TanStack Router (SPA/PWA) instead of Next.js.** 89 of 91 component files are already `'use client'`; only `app/layout.tsx` and `app/brand/page.tsx` render on the server, and the only server APIs in use are `generateMetadata` and next-intl's cookie read. The app carries hydration workarounds (`suppressHydrationWarning`, `mounted` gates, the dashboard's `isHydrated` gate) for a server pass that produces nothing usable. shadcn/Radix/recharts/dnd-kit port unchanged.
- **Views become real routes**; month and year move to URL params, so deep links, the back button, and reload-in-place work.
- **Local-first, with no storage abstraction until cloud sync exists.** The current 17-method `StorageAdapter` has 15 no-op stubs in local mode.
- **Money as integer cents.**
- **Recurrence stored as a rule** rather than materialised into 25 rows per action.
- **i18n enforced by lint and CI**, not by convention.
- **Enforcement before convenience** — a skill advises, a hook enforces (see `07`).
- **TDD in `domain/`, test-after in the UI.**
- Svelte was considered and rejected — reasoning recorded in `01-target-architecture` and `.wolf/cerebrum.md`.

### Live bugs found while mapping

Documented, **not fixed** in this PR — they are behaviour the new app must not reproduce. Also recorded in `.wolf/buglog.json`.

| ID | Impact |
|---|---|
| `P-13` | `new Date('YYYY-MM-01')` parses as UTC. In `America/Sao_Paulo` every dashboard chart month label is off by one, and the monthly view's "vs previous month" compares against **two** months ago. Reproduced. |
| `P-21` | Month-over-month change divides an installment-inclusive total by an installment-exclusive one. |
| `P-10` | Installments are filed under `'parcelamento'`, renamed to `'installment'` by the v1→v2 migration — so they all count as `other` in every category breakdown. |
| `P-05` | The delete-all gate compares `'DELETAR TUDO'` while the English UI instructs the user to type `DELETE ALL`. **English users cannot delete their data.** |
| `P-22` | The delete-all dialog lists categories and credit cards among what it destroys; the code leaves both untouched. |

Also fills in `.wolf/STATUS.md`, which was still an unedited template.

---

## `07-agent-tooling` — the toolchain (commit `0dd3e4a`)

Answers which skills, plugins and MCP servers the new repo should run with, and which of them actually enforce anything.

Organised around one principle: **a skill advises, a hook enforces.** That distinction is not academic here — the old app shipped a complete 502-key i18n system *alongside* a dashboard with every string hardcoded in Portuguese (`P-08`). The infrastructure was right; nothing enforced its use. Same shape produced `.skip`ped E2E specs that still looked like coverage (`P-23`) and a coverage threshold measured over the safest code in the repo (`P-24`).

Five layers, enforcement first:

1. **Hooks, lint, CI** — the only real enforcement. Blocks hardcoded colour literals, hand-written files under `components/ui/`, bare `.sort()` on selector output, `new Date(<string>)`.
2. **Context and tasks** — keep OpenWolf, but force `STATUS.md` updates with a `Stop` hook (in this repo it sat as an unedited template for over a week). kanban-md only when agents run in parallel, otherwise it duplicates `05`. Ponytail only with the domain layer and tests excluded, because "write less code" fights a quality bar that demands a test per rendered number.
3. **Design system** — mechanical enforcement first, then a project skill holding repo-owned tokens, then `/design-sync`. `DesignSync` was tested here and needs an interactive terminal it cannot get on the web; the workaround is documented.
4. **Visual verification** — Playwright MCP over Chrome DevTools MCP: one browser stack instead of two, matching the existing E2E suite.
5. **Testing** — TDD in `domain/` (its tests are already written — `06`'s pitfall-regression table is a list of executable failing cases), test-after in the UI.

Includes a what-**not**-to-install list, and closes with the caveat that this is researched rather than integration-tested. Phase 0 now carries an exit criterion that the enforcement layer is **proven, not assumed**: a deliberate hardcoded hex and a deliberate `.skip` must both be rejected before the phase is ticked.

---

## Second commit: `fix(deps)` — unrelated CI breakage

`ddc2df0` is **not** part of the documentation work. CI was failing at the `npm ci` step on every branch, before any project code runs:

```
npm error code EUSAGE
npm error Invalid: lock file's @smithy/uuid@1.3.10 does not satisfy @smithy/uuid@1.3.14
npm error Invalid: lock file's @smithy/core@3.29.5 does not satisfy @smithy/core@3.30.0
```

This is not caused by this branch — it reproduces on a clean checkout of the base commit `c2bc8989`, which itself last passed CI on 2026-07-19. Every requirement on those two packages is a caret range, so npm re-resolves them against the registry and finds releases newer than the lock pins.

Fixed with the procedure documented in `CLAUDE.md` (`npm install --package-lock-only --ignore-scripts`). Deliberately minimal:

- `package.json` untouched
- **zero** packages added or removed
- two transitive AWS SDK bumps only: `@smithy/core` 3.29.5 → 3.30.0, `@smithy/uuid` 1.3.10 → 1.3.14
- 7 insertions, 7 deletions

Happy to split this into its own PR if you'd prefer it separated from the docs — it's isolated in a single commit either way.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / technical debt — the lock-file resync only
- [x] Documentation

## Checklist

- [x] `npm run quality` passes (typecheck + lint + format) — verified locally; `format:check` re-run after adding `07`
- [x] `npm run test` passes with no regressions — **27 files, 324 tests, all passing**
- [x] Both `en.json` and `pt.json` updated (if UI strings changed) — n/a, no UI strings changed
- [x] No hardcoded strings — n/a, no components changed

### For new UI components

n/a — no components in this PR.

### For new screens / routes

n/a — no routes in this PR.

### For new utility / business logic

n/a — no application logic in this PR.

### Documentation-specific verification

- [x] All cross-references resolve: 24/24 pitfalls defined and referenced, 24 anchors ↔ 24 anchor links, 15/15 features, 7/7 ADRs — no dead links
- [x] `07` cross-references verified: every `P-xx` it cites exists in `04`; linked from `README`, `05` and `06`
- [x] Every factual claim cites a file and line range in this repo, re-checkable against the tree
- [x] `P-13` reproduced by executing the offending expressions under `TZ=America/Sao_Paulo`
- [x] `format:check` passes against the repo's real Prettier config, so embedded code samples match project style (`semi: false`, `singleQuote: true`)